### PR TITLE
Switched setup go action to official one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,8 @@ jobs:
     name: run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-
-      - name: run
-        uses: cedrickring/golang-action@1.7.0
-        env:
-          GO111MODULE: "on"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
-          args: make test
+          go-version: '^1.16.0'
+      - run: make test


### PR DESCRIPTION
# Proposed Changes

- Use the official `setup-go` action to prepare the golang environment 