### PR TITLE
Add region field to `Scope` resource

### DIFF
--- a/apis/core/v1alpha1/scope_types.go
+++ b/apis/core/v1alpha1/scope_types.go
@@ -25,6 +25,8 @@ import (
 type ScopeSpec struct {
 	// Description is a human-readable description of what the scope is used for.
 	Description string `json:"description,omitempty"`
+	// Region describes the region scope
+	Region string `json:"region,omitempty"`
 }
 
 // ScopeStatus defines the observed state of Scope
@@ -37,7 +39,7 @@ type ScopeStatus struct {
 	ParentScope string `json:"parentScope"`
 	// ParentNamespace represents the namespace of the parent scope
 	ParentNamespace string `json:"parentNamespace"`
-	// Account descibes the account this scope belongs to
+	// Account describes the account this scope belongs to
 	Account string `json:"account"`
 }
 

--- a/config/crd/bases/core.onmetal.de_scopes.yaml
+++ b/config/crd/bases/core.onmetal.de_scopes.yaml
@@ -59,12 +59,15 @@ spec:
                 description: Description is a human-readable description of what the
                   scope is used for.
                 type: string
+              region:
+                description: Region describes the region scope
+                type: string
             type: object
           status:
             description: ScopeStatus defines the observed state of Scope
             properties:
               account:
-                description: Account descibes the account this scope belongs to
+                description: Account describes the account this scope belongs to
                 type: string
               message:
                 description: Message contains a message for the corresponding state

--- a/config/samples/core_v1alpha1_scope.yaml
+++ b/config/samples/core_v1alpha1_scope.yaml
@@ -3,4 +3,5 @@ kind: Scope
 metadata:
   name: scope-sample
 spec:
+  #region: frankfurt1
   description: yolo

--- a/docs/design/reasoning.md
+++ b/docs/design/reasoning.md
@@ -1,0 +1,26 @@
+# Why certain design decisions have been made
+
+## Namespace replication
+
+Namespaces should be replicated from the user facing (global API) to the 
+corresponding region specific API machinery based on the regional notion of the
+namespace. This is determined by the `region` field in the scope definition
+
+```yaml
+apiVersion: core.onmetal.de/v1alpha1
+kind: Scope
+metadata:
+  name: scope-sample
+spec:
+  region: frankfurt1
+  description: "my scope"
+```
+
+In case the `region` field is empty, as it is an optional field, the namespace will
+be synced down to all infrastructure clusters.
+
+The idea of keeping track of how many regional objects are in a particular namespace
+has been dismissed, as it is hard to track how many of those objects are inside a namespace, 
+especially since this has to be done in the `parant` hierarchy as well.
+
+As a result of this descission the `region` field on all given objects must be immutable.


### PR DESCRIPTION
# Proposed Changes

- The `Scope` resource has now an optional field `region` 