### PR TITLE
Use multi arch docker image for mkdocs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:7.2.6
+FROM ghcr.io/afritzler/mkdocs-material:7.2.5
 
 LABEL project=onmetal_api_documentation
 


### PR DESCRIPTION
# Proposed Changes

Use multi arch docker image for mkdocs in order to properly run on arm64 machines.