### PR TITLE
Remove arch flag and add ldflag to remove dwarf and symbol table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM golang:1.17.0 as builder
 
+ARG GOARCH=''
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -17,7 +19,7 @@ COPY predicates/ predicates/
 COPY equality/ equality/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH:-$(go env GOARCH)} GO111MODULE=on go build -ldflags="-s -w" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
# Proposed Changes

- Currently are are building our Docker images hard against `amd64` even though we have a multi arch docker build action. We should rely on the build environments GORACH settings here.
- Add `ldflags` to remove DWARF symbol and debug table from the binary to reduce the file size (https://pkg.go.dev/cmd/link).