### PR TITLE
added timeout for docker builds in workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           docker context create builders
       - name: Set up Docker Buildx
-        # timeout-minutes: 5
+        timeout-minutes: 5
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
@@ -60,7 +60,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        # timeout-minutes: 40
+        timeout-minutes: 40
         uses: docker/build-push-action@v2
         with:
           context: .


### PR DESCRIPTION
# Proposed Changes

- Increase Docker buildx setup timeout to 5 min
- Increase Docker build and push timeout to 40 min

Fixes #255 