### PR TITLE
Make webhook configs coherent

### DIFF
--- a/apis/compute/v1alpha1/machine_webhook.go
+++ b/apis/compute/v1alpha1/machine_webhook.go
@@ -28,7 +28,7 @@ import (
 var machinelog = logf.Log.WithName("machine-resource")
 
 // "verbs=update" since only update validation is enabled
-//+kubebuilder:webhook:path=/validate-compute-onmetal-de-v1alpha1-machine,mutating=false,failurePolicy=fail,sideEffects=None,groups=compute.onmetal.de,resources=machines,verbs=update,versions=v1alpha1,name=machine.v1alpha1.compute.onmetal.de,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-compute-onmetal-de-v1alpha1-machine,mutating=false,failurePolicy=fail,sideEffects=None,groups=compute.onmetal.de,resources=machines,verbs=update,versions=v1alpha1,name=vmachine.compute.onmetal.de,admissionReviewVersions=v1
 
 // SetupWebhookWithManager creates a new webhook which will be started by mgr
 func (m *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {

--- a/apis/network/v1alpha1/ipamrange_webhook.go
+++ b/apis/network/v1alpha1/ipamrange_webhook.go
@@ -45,7 +45,7 @@ func (r *IPAMRange) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-network-onmetal-de-v1alpha1-ipamrange,mutating=true,failurePolicy=fail,sideEffects=None,groups=network.onmetal.de,resources=ipamranges,verbs=create;update,versions=v1alpha1,name=mipamrange.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-network-onmetal-de-v1alpha1-ipamrange,mutating=true,failurePolicy=fail,sideEffects=None,groups=network.onmetal.de,resources=ipamranges,verbs=create;update,versions=v1alpha1,name=mipamrange.network.onmetal.de,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &IPAMRange{}
 
@@ -54,7 +54,7 @@ func (r *IPAMRange) Default() {
 	ipamrangelog.Info("default", "name", r.Name)
 }
 
-//+kubebuilder:webhook:path=/validate-network-onmetal-de-v1alpha1-ipamrange,mutating=false,failurePolicy=fail,sideEffects=None,groups=network.onmetal.de,resources=ipamranges,verbs=create;update;delete,versions=v1alpha1,name=vipamrange.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-network-onmetal-de-v1alpha1-ipamrange,mutating=false,failurePolicy=fail,sideEffects=None,groups=network.onmetal.de,resources=ipamranges,verbs=create;update;delete,versions=v1alpha1,name=vipamrange.network.onmetal.de,admissionReviewVersions=v1
 
 var _ webhook.Validator = &IPAMRange{}
 

--- a/apis/storage/v1alpha1/volume_webhook.go
+++ b/apis/storage/v1alpha1/volume_webhook.go
@@ -40,7 +40,7 @@ func (r *Volume) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-storage-onmetal-de-v1alpha1-volume,mutating=false,failurePolicy=fail,sideEffects=None,groups=storage.onmetal.de,resources=volumes,verbs=create;update,versions=v1alpha1,name=vvolume.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-storage-onmetal-de-v1alpha1-volume,mutating=false,failurePolicy=fail,sideEffects=None,groups=storage.onmetal.de,resources=volumes,verbs=create;update,versions=v1alpha1,name=vvolume.storage.onmetal.de,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Volume{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -8,14 +8,13 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
       path: /mutate-network-onmetal-de-v1alpha1-ipamrange
   failurePolicy: Fail
-  name: mipamrange.kb.io
+  name: mipamrange.network.onmetal.de
   rules:
   - apiGroups:
     - network.onmetal.de
@@ -37,14 +36,13 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
       path: /validate-compute-onmetal-de-v1alpha1-machine
   failurePolicy: Fail
-  name: machine.v1alpha1.compute.onmetal.de
+  name: vmachine.compute.onmetal.de
   rules:
   - apiGroups:
     - compute.onmetal.de
@@ -57,14 +55,13 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
       namespace: system
       path: /validate-network-onmetal-de-v1alpha1-ipamrange
   failurePolicy: Fail
-  name: vipamrange.kb.io
+  name: vipamrange.network.onmetal.de
   rules:
   - apiGroups:
     - network.onmetal.de
@@ -85,7 +82,7 @@ webhooks:
       namespace: system
       path: /validate-storage-onmetal-de-v1alpha1-volume
   failurePolicy: Fail
-  name: vvolume.kb.io
+  name: vvolume.storage.onmetal.de
   rules:
   - apiGroups:
     - storage.onmetal.de


### PR DESCRIPTION
# Proposed Changes

- Use only admission.k8s.io/v1 since v1beta1 is [deprecated](https://github.com/kubernetes/api/blob/e869828229a838f42cf5b64bd46b135af8c7e66f/admission/v1beta1/types.go#L28).
- Use meaningful domain name for webhook [names](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/57d4c38d9beb316d7b1bea4bbef9b490d8922eca/config/webhook/manifests.yaml#L19).