### PR TITLE
Validate kustomizations in the `config` folder

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,20 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  kustomize-validation:
+    runs-on: self-hosted
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - uses: imranismail/setup-kustomize@v1
+        with:
+          kustomize-version: 4.5.2
+      - run: |
+          ./hack/validate_kustomize.sh

--- a/hack/validate_kustomize.sh
+++ b/hack/validate_kustomize.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASEDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+for dir in "$BASEDIR"/../config/*
+do
+  [[ -e "$dir" ]] || break
+  [[ "$dir" != *"config/samples"* ]] || break
+  kustomize build "$dir" > /dev/null
+done


### PR DESCRIPTION
# Proposed Changes

Run a `kustomize build` on each `config` folder to ensure that we always merge valid kustomization yamls.

Fixes #306 