### PR TITLE
Add `deviceID` to `VolumeAttachmentStatus`

### DIFF
--- a/apis/compute/v1alpha1/machine_types.go
+++ b/apis/compute/v1alpha1/machine_types.go
@@ -127,6 +127,8 @@ type VolumeAttachmentStatus struct {
 	Name string `json:"name"`
 	// Priority is the OS priority of the volume.
 	Priority int32 `json:"priority,omitempty"`
+	// DeviceID is the disk device ID on the host.
+	DeviceID string `json:"deviceID,omitempty"`
 }
 
 // MachineStatus defines the observed state of Machine

--- a/config/crd/bases/compute.onmetal.de_machines.yaml
+++ b/config/crd/bases/compute.onmetal.de_machines.yaml
@@ -320,6 +320,9 @@ spec:
                 items:
                   description: VolumeAttachmentStatus is the status of a VolumeAttachment.
                   properties:
+                    deviceID:
+                      description: DeviceID is the disk device ID on the host.
+                      type: string
                     name:
                       description: Name is the name of a volume attachment.
                       type: string


### PR DESCRIPTION
# Proposed Changes

Add `deviceID` field to the `VolumeAttachmentStatus` of a `Machine`.