### PR TITLE
Enhance NAT Gateway Destination reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,11 @@ generate: vgopath models-schema deepcopy-gen client-gen lister-gen informer-gen 
 	./hack/update-codegen.sh
 
 .PHONY: proto
-proto: vgopath protoc-gen-gogo
+proto: goimports vgopath protoc-gen-gogo
 	VGOPATH=$(VGOPATH) \
 	PROTOC_GEN_GOGO=$(PROTOC_GEN_GOGO) \
 	./hack/update-proto.sh
+	$(GOIMPORTS) -w ./ori
 
 .PHONY: fmt
 fmt: goimports ## Run goimports against code.

--- a/cmd/onmetal-controller-manager/main.go
+++ b/cmd/onmetal-controller-manager/main.go
@@ -375,7 +375,7 @@ func main() {
 	}
 
 	if controllers.Enabled(natGatewayController) {
-		if err := (&networkingcontrollers.NatGatewayReconciler{
+		if err := (&networkingcontrollers.NATGatewayReconciler{
 			Client:        mgr.GetClient(),
 			Scheme:        mgr.GetScheme(),
 			EventRecorder: mgr.GetEventRecorderFor("natgateways"),

--- a/internal/controllers/networking/aliasprefix_controller_test.go
+++ b/internal/controllers/networking/aliasprefix_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("AliasPrefixReconciler", func() {
 	ctx := SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
 	It("should reconcile the prefix and routing destinations", func() {
 		By("creating a network")

--- a/internal/controllers/networking/loadbalancer_controller_test.go
+++ b/internal/controllers/networking/loadbalancer_controller_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("LoadBalancerReconciler", func() {
 	ctx := SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
 	It("should reconcile the prefix and routing destinations", func() {
 		By("creating a network")

--- a/internal/controllers/networking/network_protection_controller_test.go
+++ b/internal/controllers/networking/network_protection_controller_test.go
@@ -30,7 +30,7 @@ import (
 
 var _ = Describe("NetworkProtectionReconciler", func() {
 	ctx := SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
 	var (
 		network *networkingv1alpha1.Network

--- a/internal/controllers/networking/networkbind_controller_test.go
+++ b/internal/controllers/networking/networkbind_controller_test.go
@@ -33,8 +33,7 @@ var IgnoreNetworkPeeringStatusVolatileFields = cmpopts.IgnoreFields(
 )
 
 var _ = Describe("NetworkBindReconciler", func() {
-	ctx := SetupContext()
-	ns1, _ := SetupTest(ctx)
+	ns1, _ := SetupTest()
 	ns2 := SetupNamespace(&k8sClient)
 
 	It("should bind two networks in the same namespace referencing each other", func(ctx SpecContext) {

--- a/internal/controllers/networking/networkinterface_controller_test.go
+++ b/internal/controllers/networking/networkinterface_controller_test.go
@@ -30,7 +30,7 @@ import (
 
 var _ = Describe("NetworkInterfaceReconciler", func() {
 	ctx := SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 	const networkHandle = "foo"
 
 	It("should reconcile the ips and update the status", func() {

--- a/internal/controllers/networking/networkinterfacebind_controller_test.go
+++ b/internal/controllers/networking/networkinterfacebind_controller_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("NetworkInterfaceBindReconciler", func() {
 	ctx := SetupContext()
-	ns, machineClass := SetupTest(ctx)
+	ns, machineClass := SetupTest()
 
 	It("should reconcile the binding phase", func() {
 		By("creating a network")

--- a/internal/controllers/networking/suite_test.go
+++ b/internal/controllers/networking/suite_test.go
@@ -178,7 +178,7 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&NatGatewayReconciler{
+	err = (&NATGatewayReconciler{
 		EventRecorder: &record.FakeRecorder{},
 		Client:        k8sManager.GetClient(),
 		Scheme:        k8sManager.GetScheme(),
@@ -212,18 +212,20 @@ var _ = BeforeSuite(func() {
 	}()
 })
 
-func SetupTest(ctx context.Context) (*corev1.Namespace, *computev1alpha1.MachineClass) {
+func SetupTest() (*corev1.Namespace, *computev1alpha1.MachineClass) {
 	var (
 		ns           = &corev1.Namespace{}
 		machineClass = &computev1alpha1.MachineClass{}
 	)
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		*ns = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "testns-"},
 		}
 		Expect(k8sClient.Create(ctx, ns)).NotTo(HaveOccurred(), "failed to create test namespace")
-		DeferCleanup(k8sClient.Delete, ctx, ns)
+		DeferCleanup(func(ctx context.Context) error {
+			return client.IgnoreNotFound(k8sClient.Delete(ctx, ns))
+		})
 
 		*machineClass = computev1alpha1.MachineClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -235,7 +237,9 @@ func SetupTest(ctx context.Context) (*corev1.Namespace, *computev1alpha1.Machine
 			},
 		}
 		Expect(k8sClient.Create(ctx, machineClass)).To(Succeed(), "failed to create test machine class")
-		DeferCleanup(k8sClient.Delete, ctx, machineClass)
+		DeferCleanup(func(ctx context.Context) error {
+			return client.IgnoreNotFound(k8sClient.Delete(ctx, machineClass))
+		})
 	})
 
 	return ns, machineClass

--- a/internal/controllers/networking/virtualip_controller_test.go
+++ b/internal/controllers/networking/virtualip_controller_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("VirtualIPReconciler", func() {
 	ctx := SetupContext()
-	ns, _ := SetupTest(ctx)
+	ns, _ := SetupTest()
 
 	It("should set a virtual ip to unbound if nothing binds it", func() {
 		By("creating a virtual ip")

--- a/ori/apis/bucket/v1alpha1/api.pb.go
+++ b/ori/apis/bucket/v1alpha1/api.pb.go
@@ -6,6 +6,12 @@ package v1alpha1
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	reflect "reflect"
+	strings "strings"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
@@ -13,11 +19,6 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-	reflect "reflect"
-	strings "strings"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ori/apis/machine/v1alpha1/api.pb.go
+++ b/ori/apis/machine/v1alpha1/api.pb.go
@@ -6,6 +6,12 @@ package v1alpha1
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	reflect "reflect"
+	strings "strings"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
@@ -13,11 +19,6 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-	reflect "reflect"
-	strings "strings"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ori/apis/meta/v1alpha1/api.pb.go
+++ b/ori/apis/meta/v1alpha1/api.pb.go
@@ -5,14 +5,15 @@ package v1alpha1
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/ori/apis/volume/v1alpha1/api.pb.go
+++ b/ori/apis/volume/v1alpha1/api.pb.go
@@ -6,6 +6,12 @@ package v1alpha1
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+	reflect "reflect"
+	strings "strings"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
@@ -13,11 +19,6 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-	reflect "reflect"
-	strings "strings"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
* Fix an issue with outdated destinations not getting updated when NAT gateway IPs change
* Fix ip / port allocation with multiple IP families
* Enhance test cases to not automatically compute too many values