### PR TITLE
Add `Network` peering states `Ready`, `Error` & `Pending`

### DIFF
--- a/api/networking/v1alpha1/network_type.go
+++ b/api/networking/v1alpha1/network_type.go
@@ -74,8 +74,10 @@ type NetworkPeeringState string
 const (
 	// NetworkPeeringStatePending signals that the network peering is not applied.
 	NetworkPeeringStatePending NetworkPeeringState = "Pending"
-	// NetworkPeeringStateApplied signals that the network peering is applied.
-	NetworkPeeringStateApplied NetworkPeeringState = "Applied"
+	// NetworkPeeringStateReady signals that the network peering is ready.
+	NetworkPeeringStateReady NetworkPeeringState = "Ready"
+	// NetworkPeeringStateError signals that the network peering is in error state.
+	NetworkPeeringStateError NetworkPeeringState = "Error"
 )
 
 // NetworkPeeringStatus is the status of a network peering.

--- a/docs/api-reference/compute.md
+++ b/docs/api-reference/compute.md
@@ -1178,6 +1178,9 @@ MachinePool.</p>
 </tr><tr><td><p>&#34;Terminated&#34;</p></td>
 <td><p>MachineStateTerminated means the machine has been permanently stopped and cannot be started.</p>
 </td>
+</tr><tr><td><p>&#34;Terminating&#34;</p></td>
+<td><p>MachineStateTerminating means the machine that is terminating.</p>
+</td>
 </tr></tbody>
 </table>
 <h3 id="compute.ironcore.dev/v1alpha1.MachineStatus">MachineStatus

--- a/docs/api-reference/networking.md
+++ b/docs/api-reference/networking.md
@@ -2003,6 +2003,32 @@ string
 </tr>
 </tbody>
 </table>
+<h3 id="networking.ironcore.dev/v1alpha1.NetworkPeeringState">NetworkPeeringState
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#networking.ironcore.dev/v1alpha1.NetworkPeeringStatus">NetworkPeeringStatus</a>)
+</p>
+<div>
+<p>NetworkPeeringState is the state a NetworkPeering can be in</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Error&#34;</p></td>
+<td><p>NetworkPeeringStateError signals that the network peering is in error state.</p>
+</td>
+</tr><tr><td><p>&#34;Pending&#34;</p></td>
+<td><p>NetworkPeeringStatePending signals that the network peering is not applied.</p>
+</td>
+</tr><tr><td><p>&#34;Ready&#34;</p></td>
+<td><p>NetworkPeeringStateReady signals that the network peering is ready.</p>
+</td>
+</tr></tbody>
+</table>
 <h3 id="networking.ironcore.dev/v1alpha1.NetworkPeeringStatus">NetworkPeeringStatus
 </h3>
 <p>
@@ -2028,6 +2054,19 @@ string
 </td>
 <td>
 <p>Name is the name of the network peering.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+<a href="#networking.ironcore.dev/v1alpha1.NetworkPeeringState">
+NetworkPeeringState
+</a>
+</em>
+</td>
+<td>
+<p>State represents the network peering state</p>
 </td>
 </tr>
 </tbody>

--- a/internal/apis/networking/network_type.go
+++ b/internal/apis/networking/network_type.go
@@ -74,8 +74,10 @@ type NetworkPeeringState string
 const (
 	// NetworkPeeringStatePending signals that the network peering is not applied.
 	NetworkPeeringStatePending NetworkPeeringState = "Pending"
-	// NetworkPeeringStateApplied signals that the network peering is applied.
-	NetworkPeeringStateApplied NetworkPeeringState = "Applied"
+	// NetworkPeeringStateReady signals that the network peering is ready.
+	NetworkPeeringStateReady NetworkPeeringState = "Ready"
+	// NetworkPeeringStateError signals that the network peering is in error state.
+	NetworkPeeringStateError NetworkPeeringState = "Error"
 )
 
 // NetworkPeeringStatus is the status of a network peering.

--- a/internal/controllers/networking/network_peering_controller_test.go
+++ b/internal/controllers/networking/network_peering_controller_test.go
@@ -550,4 +550,101 @@ var _ = Describe("NetworkPeeringController", func() {
 		Eventually(Get(network2)).Should(Satisfy(apierrors.IsNotFound))
 		Eventually(Get(network3)).Should(Satisfy(apierrors.IsNotFound))
 	})
+
+	It("should skip network peering for that network only if network does not exist referencing a single parent network", func(ctx SpecContext) {
+		By("creating a network network-1")
+		network1 := &networkingv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      "network-1",
+			},
+			Spec: networkingv1alpha1.NetworkSpec{
+				Peerings: []networkingv1alpha1.NetworkPeering{
+					{
+						Name: "peering-1",
+						NetworkRef: networkingv1alpha1.NetworkPeeringNetworkRef{
+							Name:      "network-2",
+							Namespace: ns.Name,
+						},
+					},
+					{
+						Name: "peering-2",
+						NetworkRef: networkingv1alpha1.NetworkPeeringNetworkRef{
+							Name: "network-3",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, network1)).To(Succeed())
+
+		By("creating a network network-3")
+		network3 := &networkingv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      "network-3",
+			},
+			Spec: networkingv1alpha1.NetworkSpec{
+				Peerings: []networkingv1alpha1.NetworkPeering{
+					{
+						Name: "peering-3",
+						NetworkRef: networkingv1alpha1.NetworkPeeringNetworkRef{
+							Name:      "network-1",
+							Namespace: ns.Name,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, network3)).To(Succeed())
+
+		By("patching networks as available")
+		baseNetwork1 := network1.DeepCopy()
+		network1.Status.State = networkingv1alpha1.NetworkStateAvailable
+		Expect(k8sClient.Status().Patch(ctx, network1, client.MergeFrom(baseNetwork1))).To(Succeed())
+
+		baseNetwork3 := network3.DeepCopy()
+		network3.Status.State = networkingv1alpha1.NetworkStateAvailable
+		Expect(k8sClient.Status().Patch(ctx, network3, client.MergeFrom(baseNetwork3))).To(Succeed())
+
+		By("waiting for networks to reference each other")
+		Eventually(Object(network1)).
+			Should(SatisfyAll(
+				HaveField("Spec.PeeringClaimRefs", ConsistOf(networkingv1alpha1.NetworkPeeringClaimRef{
+					Namespace: network3.Namespace,
+					Name:      network3.Name,
+					UID:       network3.UID,
+				})),
+				HaveField("Status.State", Equal(networkingv1alpha1.NetworkStateAvailable)),
+				HaveField("Status.Peerings", ConsistOf(networkingv1alpha1.NetworkPeeringStatus{
+					Name:  network1.Spec.Peerings[0].Name,
+					State: networkingv1alpha1.NetworkPeeringStatePending,
+				}, networkingv1alpha1.NetworkPeeringStatus{
+					Name:  network1.Spec.Peerings[1].Name,
+					State: networkingv1alpha1.NetworkPeeringStatePending,
+				})),
+			))
+
+		Eventually(Object(network3)).
+			Should(SatisfyAll(
+				HaveField("Spec.PeeringClaimRefs", ConsistOf(networkingv1alpha1.NetworkPeeringClaimRef{
+					Namespace: network1.Namespace,
+					Name:      network1.Name,
+					UID:       network1.UID,
+				})),
+				HaveField("Status.State", Equal(networkingv1alpha1.NetworkStateAvailable)),
+				HaveField("Status.Peerings", ConsistOf(networkingv1alpha1.NetworkPeeringStatus{
+					Name:  network3.Spec.Peerings[0].Name,
+					State: networkingv1alpha1.NetworkPeeringStatePending,
+				})),
+			))
+
+		By("deleting the networks")
+		Expect(k8sClient.Delete(ctx, network1)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, network3)).To(Succeed())
+
+		By("waiting for networks to be gone")
+		Eventually(Get(network1)).Should(Satisfy(apierrors.IsNotFound))
+		Eventually(Get(network3)).Should(Satisfy(apierrors.IsNotFound))
+	})
 })

--- a/internal/controllers/networking/network_peering_controller_test.go
+++ b/internal/controllers/networking/network_peering_controller_test.go
@@ -551,7 +551,7 @@ var _ = Describe("NetworkPeeringController", func() {
 		Eventually(Get(network3)).Should(Satisfy(apierrors.IsNotFound))
 	})
 
-	It("should skip network peering for that network only if network does not exist referencing a single parent network", func(ctx SpecContext) {
+	It("should skip network peering for a non-existing network", func(ctx SpecContext) {
 		By("creating a network network-1")
 		network1 := &networkingv1alpha1.Network{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Proposed Changes

- Add network peering states - Ready and Error
- Remove network peering state - Applied
- Add test to validate if one of the peered network is unavailable, controller continues to peer other networks.

Fixes #1054