### PR TITLE
Fix peering prefix validation for `prefixRef` name

### DIFF
--- a/internal/apis/networking/validation/network.go
+++ b/internal/apis/networking/validation/network.go
@@ -156,8 +156,10 @@ func validatePeeringPrefix(prefix networking.PeeringPrefix, fldPath *field.Path)
 	}
 
 	prefixRef := prefix.PrefixRef
-	for _, msg := range apivalidation.NameIsDNSLabel(prefixRef.Name, false) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("prefixRef", "name"), prefixRef.Name, msg))
+	if prefixRef.Name != "" {
+		for _, msg := range apivalidation.NameIsDNSLabel(prefixRef.Name, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("prefixRef", "name"), prefixRef.Name, msg))
+		}
 	}
 
 	return allErrs


### PR DESCRIPTION
# Proposed Changes

- Validate peering prefix name only when its not empty.
