### PR TITLE
Fix `PeeringClaimRefs` modification in `NetworkPeering` controller

### DIFF
--- a/internal/controllers/networking/network_peering_controller.go
+++ b/internal/controllers/networking/network_peering_controller.go
@@ -60,11 +60,9 @@ func (r *NetworkPeeringReconciler) reconcile(ctx context.Context, log logr.Logge
 		}
 	}
 
-	if len(peeringClaimRefs) > 0 {
-		log.V(1).Info("Peering claim refs require network spec update")
-		if err := r.updateSpec(ctx, log, network, peeringClaimRefs); err != nil {
-			return ctrl.Result{}, fmt.Errorf("error updating network spec: %w", err)
-		}
+	log.V(1).Info("Peering claim refs require network spec update")
+	if err := r.updateSpec(ctx, log, network, peeringClaimRefs); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error updating network spec: %w", err)
 	}
 
 	log.V(1).Info("Reconciled")


### PR DESCRIPTION
# Proposed Changes

- Modify `PeeringClaimRefs` when one of the matched peering is removed
- Add test case to  simulate this behavior