### PR TITLE
fixing wrong restconfig reference

### DIFF
--- a/utils/client/config/config.go
+++ b/utils/client/config/config.go
@@ -303,7 +303,7 @@ func (g *Getter) getAndBootstrapConfigIfNecessary(ctx context.Context, o *GetCon
 		return nil, nil, fmt.Errorf("error loading bootstrap kubeconfig: %w", err)
 	}
 	if bootstrapCfg != nil {
-		cfg.Dial = dialFunc
+		bootstrapCfg.Dial = dialFunc
 	}
 
 	if cfg == nil && bootstrapCfg == nil {


### PR DESCRIPTION
# Proposed Changes

- changes to the correct restconfig in case a bootstrap-kubeconfig is used

Fixes #

- Prevents panic in case only bootstrap-kubeconfig is used to generate real kubeconfig