### PR TITLE
Added `VolumeRef` to `Machine` status

### DIFF
--- a/api/compute/v1alpha1/machine_types.go
+++ b/api/compute/v1alpha1/machine_types.go
@@ -160,6 +160,8 @@ type VolumeStatus struct {
 	State VolumeState `json:"state,omitempty"`
 	// LastStateTransitionTime is the last time the State transitioned.
 	LastStateTransitionTime *metav1.Time `json:"lastStateTransitionTime,omitempty"`
+	// VolumeRef reference to the claimed Volume
+	VolumeRef corev1.LocalObjectReference `json:"volumeRef,omitempty"`
 }
 
 // VolumeState is the infrastructure attachment state a Volume can be in.

--- a/api/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/api/compute/v1alpha1/zz_generated.deepcopy.go
@@ -672,6 +672,7 @@ func (in *VolumeStatus) DeepCopyInto(out *VolumeStatus) {
 		in, out := &in.LastStateTransitionTime, &out.LastStateTransitionTime
 		*out = (*in).DeepCopy()
 	}
+	out.VolumeRef = in.VolumeRef
 	return
 }
 

--- a/client-go/applyconfigurations/compute/v1alpha1/volumestatus.go
+++ b/client-go/applyconfigurations/compute/v1alpha1/volumestatus.go
@@ -7,16 +7,18 @@ package v1alpha1
 
 import (
 	v1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // VolumeStatusApplyConfiguration represents an declarative configuration of the VolumeStatus type for use
 // with apply.
 type VolumeStatusApplyConfiguration struct {
-	Name                    *string               `json:"name,omitempty"`
-	Handle                  *string               `json:"handle,omitempty"`
-	State                   *v1alpha1.VolumeState `json:"state,omitempty"`
-	LastStateTransitionTime *v1.Time              `json:"lastStateTransitionTime,omitempty"`
+	Name                    *string                      `json:"name,omitempty"`
+	Handle                  *string                      `json:"handle,omitempty"`
+	State                   *v1alpha1.VolumeState        `json:"state,omitempty"`
+	LastStateTransitionTime *v1.Time                     `json:"lastStateTransitionTime,omitempty"`
+	VolumeRef               *corev1.LocalObjectReference `json:"volumeRef,omitempty"`
 }
 
 // VolumeStatusApplyConfiguration constructs an declarative configuration of the VolumeStatus type for use with
@@ -54,5 +56,13 @@ func (b *VolumeStatusApplyConfiguration) WithState(value v1alpha1.VolumeState) *
 // If called multiple times, the LastStateTransitionTime field is set to the value of the last call.
 func (b *VolumeStatusApplyConfiguration) WithLastStateTransitionTime(value v1.Time) *VolumeStatusApplyConfiguration {
 	b.LastStateTransitionTime = &value
+	return b
+}
+
+// WithVolumeRef sets the VolumeRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the VolumeRef field is set to the value of the last call.
+func (b *VolumeStatusApplyConfiguration) WithVolumeRef(value corev1.LocalObjectReference) *VolumeStatusApplyConfiguration {
+	b.VolumeRef = &value
 	return b
 }

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -433,6 +433,10 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: state
       type:
         scalar: string
+    - name: volumeRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+      default: {}
 - name: com.github.ironcore-dev.ironcore.api.core.v1alpha1.ObjectSelector
   map:
     fields:

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1840,12 +1840,19 @@ func schema_ironcore_api_compute_v1alpha1_VolumeStatus(ref common.ReferenceCallb
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"volumeRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VolumeRef reference to the claimed Volume",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/gen/swagger.json
+++ b/gen/swagger.json
@@ -65371,6 +65371,10 @@
 				"state": {
 					"description": "State represents the attachment state of a Volume.",
 					"type": "string"
+				},
+				"volumeRef": {
+					"description": "VolumeRef reference to the claimed Volume",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
 				}
 			}
 		},

--- a/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
@@ -4883,6 +4883,15 @@
 					"state": {
 						"description": "State represents the attachment state of a Volume.",
 						"type": "string"
+					},
+					"volumeRef": {
+						"description": "VolumeRef reference to the claimed Volume",
+						"default": {},
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
 					}
 				}
 			},

--- a/internal/apis/compute/machine_types.go
+++ b/internal/apis/compute/machine_types.go
@@ -150,6 +150,8 @@ type VolumeStatus struct {
 	State VolumeState
 	// LastStateTransitionTime is the last time the State transitioned.
 	LastStateTransitionTime *metav1.Time
+	//VolumeRef reference to the claimed Volume
+	VolumeRef corev1.LocalObjectReference
 }
 
 // VolumeState is the infrastructure attachment state a Volume can be in.

--- a/internal/apis/compute/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/compute/v1alpha1/zz_generated.conversion.go
@@ -970,6 +970,7 @@ func autoConvert_v1alpha1_VolumeStatus_To_compute_VolumeStatus(in *v1alpha1.Volu
 	out.Handle = in.Handle
 	out.State = compute.VolumeState(in.State)
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
+	out.VolumeRef = in.VolumeRef
 	return nil
 }
 
@@ -983,6 +984,7 @@ func autoConvert_compute_VolumeStatus_To_v1alpha1_VolumeStatus(in *compute.Volum
 	out.Handle = in.Handle
 	out.State = v1alpha1.VolumeState(in.State)
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
+	out.VolumeRef = in.VolumeRef
 	return nil
 }
 

--- a/internal/apis/compute/zz_generated.deepcopy.go
+++ b/internal/apis/compute/zz_generated.deepcopy.go
@@ -667,6 +667,7 @@ func (in *VolumeStatus) DeepCopyInto(out *VolumeStatus) {
 		in, out := &in.LastStateTransitionTime, &out.LastStateTransitionTime
 		*out = (*in).DeepCopy()
 	}
+	out.VolumeRef = in.VolumeRef
 	return
 }
 

--- a/internal/app/app_suite_test.go
+++ b/internal/app/app_suite_test.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	pollingInterval      = 50 * time.Millisecond
-	eventuallyTimeout    = 3 * time.Second
+	eventuallyTimeout    = 5 * time.Second
 	consistentlyDuration = 1 * time.Second
 	apiServiceTimeout    = 5 * time.Minute
 )

--- a/internal/app/core_test.go
+++ b/internal/app/core_test.go
@@ -72,14 +72,14 @@ var _ = Describe("Core", func() {
 			}
 			Expect(k8sClient.Create(ctx, machine)).To(Succeed())
 
-			By("getting the resource quota")
+			By("waiting for the resource quota to be updated")
 			resourceQuotaKey := client.ObjectKeyFromObject(resourceQuota)
-			Expect(k8sClient.Get(ctx, resourceQuotaKey, resourceQuota)).To(Succeed())
-
-			By("inspecting the resource quota")
-			Expect(resourceQuota.Status.Used).To(Equal(corev1alpha1.ResourceList{
-				corev1alpha1.ResourceRequestsCPU: resource.MustParse("1"),
-			}))
+			Eventually(func(g Gomega) {
+				Expect(k8sClient.Get(ctx, resourceQuotaKey, resourceQuota)).To(Succeed())
+				g.Expect(resourceQuota.Status.Used).To(Equal(corev1alpha1.ResourceList{
+					corev1alpha1.ResourceRequestsCPU: resource.MustParse("1"),
+				}))
+			}).Should(Succeed())
 		})
 	})
 })

--- a/poollet/machinepoollet/controllers/machine_controller_volume.go
+++ b/poollet/machinepoollet/controllers/machine_controller_volume.go
@@ -347,18 +347,18 @@ func (r *MachineReconciler) getVolumeStatusesForMachine(
 			iriVolumeStatus, ok = iriVolumeStatusByName[machineVolume.Name]
 			volumeStatusValues  computev1alpha1.VolumeStatus
 		)
+		volumeName := computev1alpha1.MachineVolumeName(machine.Name, machineVolume)
 		if ok {
 			var err error
-			volumeStatusValues, err = r.convertIRIVolumeStatus(iriVolumeStatus)
+			volumeStatusValues, err = r.convertIRIVolumeStatus(iriVolumeStatus, volumeName)
 			if err != nil {
 				return nil, fmt.Errorf("[volume %s] %w", machineVolume.Name, err)
 			}
-			volumeStatusValues.VolumeRef = corev1.LocalObjectReference{Name: computev1alpha1.MachineVolumeName(machine.Name, machineVolume)}
 		} else {
 			volumeStatusValues = computev1alpha1.VolumeStatus{
 				Name:      machineVolume.Name,
 				State:     computev1alpha1.VolumeStatePending,
-				VolumeRef: corev1.LocalObjectReference{Name: computev1alpha1.MachineVolumeName(machine.Name, machineVolume)},
+				VolumeRef: corev1.LocalObjectReference{Name: volumeName},
 			}
 		}
 
@@ -384,16 +384,17 @@ func (r *MachineReconciler) convertIRIVolumeState(iriState iri.VolumeState) (com
 	return "", fmt.Errorf("unknown iri volume state %v", iriState)
 }
 
-func (r *MachineReconciler) convertIRIVolumeStatus(iriVolumeStatus *iri.VolumeStatus) (computev1alpha1.VolumeStatus, error) {
+func (r *MachineReconciler) convertIRIVolumeStatus(iriVolumeStatus *iri.VolumeStatus, volumeName string) (computev1alpha1.VolumeStatus, error) {
 	state, err := r.convertIRIVolumeState(iriVolumeStatus.State)
 	if err != nil {
 		return computev1alpha1.VolumeStatus{}, err
 	}
 
 	return computev1alpha1.VolumeStatus{
-		Name:   iriVolumeStatus.Name,
-		Handle: iriVolumeStatus.Handle,
-		State:  state,
+		Name:      iriVolumeStatus.Name,
+		Handle:    iriVolumeStatus.Handle,
+		State:     state,
+		VolumeRef: corev1.LocalObjectReference{Name: volumeName},
 	}, nil
 }
 

--- a/poollet/machinepoollet/controllers/machine_controller_volume.go
+++ b/poollet/machinepoollet/controllers/machine_controller_volume.go
@@ -353,10 +353,12 @@ func (r *MachineReconciler) getVolumeStatusesForMachine(
 			if err != nil {
 				return nil, fmt.Errorf("[volume %s] %w", machineVolume.Name, err)
 			}
+			volumeStatusValues.VolumeRef = corev1.LocalObjectReference{Name: computev1alpha1.MachineVolumeName(machine.Name, machineVolume)}
 		} else {
 			volumeStatusValues = computev1alpha1.VolumeStatus{
-				Name:  machineVolume.Name,
-				State: computev1alpha1.VolumeStatePending,
+				Name:      machineVolume.Name,
+				State:     computev1alpha1.VolumeStatePending,
+				VolumeRef: corev1.LocalObjectReference{Name: computev1alpha1.MachineVolumeName(machine.Name, machineVolume)},
 			}
 		}
 
@@ -402,4 +404,5 @@ func (r *MachineReconciler) addVolumeStatusValues(now metav1.Time, existing, new
 	existing.Name = newValues.Name
 	existing.State = newValues.State
 	existing.Handle = newValues.Handle
+	existing.VolumeRef = newValues.VolumeRef
 }


### PR DESCRIPTION
# Proposed Changes

- Add `VolumeRef` of type corev1.LocalObjectReference to`Machine.Status.VolumeStatus` struc for identifying the claimed Volume
- Update logic to set claimed VolumeRef in machinepoollet
- Add test cases to cover ephemeral volume
- Fix sporadic test failure in `core_test.go`

Fixes #1118 