### PR TITLE
Added `NetworkInterfaceRef` to `Machine` status

### DIFF
--- a/api/compute/v1alpha1/machine_types.go
+++ b/api/compute/v1alpha1/machine_types.go
@@ -134,6 +134,8 @@ type NetworkInterfaceStatus struct {
 	VirtualIP *commonv1alpha1.IP `json:"virtualIP,omitempty"`
 	// State represents the attachment state of a NetworkInterface.
 	State NetworkInterfaceState `json:"state,omitempty"`
+	// networkInterfaceRef is the reference to the networkinterface attached to the machine
+	NetworkInterfaceRef corev1.LocalObjectReference `json:"networkInterfaceRef,omitempty"`
 	// LastStateTransitionTime is the last time the State transitioned.
 	LastStateTransitionTime *metav1.Time `json:"lastStateTransitionTime,omitempty"`
 }

--- a/api/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/api/compute/v1alpha1/zz_generated.deepcopy.go
@@ -594,6 +594,7 @@ func (in *NetworkInterfaceStatus) DeepCopyInto(out *NetworkInterfaceStatus) {
 		in, out := &in.VirtualIP, &out.VirtualIP
 		*out = (*in).DeepCopy()
 	}
+	out.NetworkInterfaceRef = in.NetworkInterfaceRef
 	if in.LastStateTransitionTime != nil {
 		in, out := &in.LastStateTransitionTime, &out.LastStateTransitionTime
 		*out = (*in).DeepCopy()

--- a/client-go/applyconfigurations/compute/v1alpha1/networkinterfacestatus.go
+++ b/client-go/applyconfigurations/compute/v1alpha1/networkinterfacestatus.go
@@ -8,7 +8,8 @@ package v1alpha1
 import (
 	v1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NetworkInterfaceStatusApplyConfiguration represents an declarative configuration of the NetworkInterfaceStatus type for use
@@ -19,7 +20,8 @@ type NetworkInterfaceStatusApplyConfiguration struct {
 	IPs                     []v1alpha1.IP                          `json:"ips,omitempty"`
 	VirtualIP               *v1alpha1.IP                           `json:"virtualIP,omitempty"`
 	State                   *computev1alpha1.NetworkInterfaceState `json:"state,omitempty"`
-	LastStateTransitionTime *v1.Time                               `json:"lastStateTransitionTime,omitempty"`
+	NetworkInterfaceRef     *v1.LocalObjectReference               `json:"networkInterfaceRef,omitempty"`
+	LastStateTransitionTime *metav1.Time                           `json:"lastStateTransitionTime,omitempty"`
 }
 
 // NetworkInterfaceStatusApplyConfiguration constructs an declarative configuration of the NetworkInterfaceStatus type for use with
@@ -70,10 +72,18 @@ func (b *NetworkInterfaceStatusApplyConfiguration) WithState(value computev1alph
 	return b
 }
 
+// WithNetworkInterfaceRef sets the NetworkInterfaceRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NetworkInterfaceRef field is set to the value of the last call.
+func (b *NetworkInterfaceStatusApplyConfiguration) WithNetworkInterfaceRef(value v1.LocalObjectReference) *NetworkInterfaceStatusApplyConfiguration {
+	b.NetworkInterfaceRef = &value
+	return b
+}
+
 // WithLastStateTransitionTime sets the LastStateTransitionTime field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LastStateTransitionTime field is set to the value of the last call.
-func (b *NetworkInterfaceStatusApplyConfiguration) WithLastStateTransitionTime(value v1.Time) *NetworkInterfaceStatusApplyConfiguration {
+func (b *NetworkInterfaceStatusApplyConfiguration) WithLastStateTransitionTime(value metav1.Time) *NetworkInterfaceStatusApplyConfiguration {
 	b.LastStateTransitionTime = &value
 	return b
 }

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -388,6 +388,10 @@ var schemaYAML = typed.YAMLObject(`types:
       type:
         scalar: string
       default: ""
+    - name: networkInterfaceRef
+      type:
+        namedType: io.k8s.api.core.v1.LocalObjectReference
+      default: {}
     - name: state
       type:
         scalar: string

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1701,6 +1701,13 @@ func schema_ironcore_api_compute_v1alpha1_NetworkInterfaceStatus(ref common.Refe
 							Format:      "",
 						},
 					},
+					"networkInterfaceRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "networkInterfaceRef is the reference to the networkinterface attached to the machine",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
 					"lastStateTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LastStateTransitionTime is the last time the State transitioned.",
@@ -1712,7 +1719,7 @@ func schema_ironcore_api_compute_v1alpha1_NetworkInterfaceStatus(ref common.Refe
 			},
 		},
 		Dependencies: []string{
-			"github.com/ironcore-dev/ironcore/api/common/v1alpha1.IP", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/ironcore-dev/ironcore/api/common/v1alpha1.IP", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/gen/swagger.json
+++ b/gen/swagger.json
@@ -65306,6 +65306,10 @@
 					"description": "Name is the name of the NetworkInterface to whom the status belongs to.",
 					"type": "string"
 				},
+				"networkInterfaceRef": {
+					"description": "networkInterfaceRef is the reference to the networkinterface attached to the machine",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				},
 				"state": {
 					"description": "State represents the attachment state of a NetworkInterface.",
 					"type": "string"
@@ -66437,6 +66441,13 @@
 				"networkRef": {
 					"description": "NetworkRef is the reference to the network to peer with. An empty namespace indicates that the target network resides in the same namespace as the source network.",
 					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.NetworkPeeringNetworkRef"
+				},
+				"prefixes": {
+					"description": "Prefixes is a list of prefixes that we want only to be exposed to the peered network, if no prefixes are specified no filtering will be done.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefix"
+					}
 				}
 			}
 		},
@@ -66487,6 +66498,13 @@
 				"name": {
 					"description": "Name is the name of the network peering.",
 					"type": "string"
+				},
+				"prefixes": {
+					"description": "Prefixes contains the prefixes exposed to the peered network",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefixStatus"
+					}
 				},
 				"state": {
 					"description": "State represents the network peering state",
@@ -66774,6 +66792,44 @@
 						"Error",
 						"Pending"
 					]
+				}
+			}
+		},
+		"com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefix": {
+			"description": "PeeringPrefixes defines prefixes to be exposed to the peered network",
+			"type": "object",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"description": "Name is the semantical name of the peering prefixes",
+					"type": "string"
+				},
+				"prefix": {
+					"description": "CIDR to be exposed to the peered network",
+					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.common.v1alpha1.IPPrefix"
+				},
+				"prefixRef": {
+					"description": "PrefixRef is the reference to the prefix to be exposed to peered network An empty namespace indicates that the prefix resides in the same namespace as the source network.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
+				}
+			}
+		},
+		"com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefixStatus": {
+			"description": "PeeringPrefixStatus lists prefixes exposed to peered network",
+			"type": "object",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"description": "Name is the name of the peering prefix",
+					"type": "string"
+				},
+				"prefix": {
+					"description": "CIDR exposed to the peered network",
+					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.common.v1alpha1.IPPrefix"
 				}
 			}
 		},

--- a/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
@@ -4791,6 +4791,15 @@
 						"type": "string",
 						"default": ""
 					},
+					"networkInterfaceRef": {
+						"description": "networkInterfaceRef is the reference to the networkinterface attached to the machine",
+						"default": {},
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					},
 					"state": {
 						"description": "State represents the attachment state of a NetworkInterface.",
 						"type": "string"

--- a/gen/v3/apis__networking.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__networking.ironcore.dev__v1alpha1_openapi.json
@@ -11857,6 +11857,18 @@
 								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.NetworkPeeringNetworkRef"
 							}
 						]
+					},
+					"prefixes": {
+						"description": "Prefixes is a list of prefixes that we want only to be exposed to the peered network, if no prefixes are specified no filtering will be done.",
+						"type": "array",
+						"items": {
+							"default": {},
+							"allOf": [
+								{
+									"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefix"
+								}
+							]
+						}
 					}
 				}
 			},
@@ -11910,6 +11922,18 @@
 						"description": "Name is the name of the network peering.",
 						"type": "string",
 						"default": ""
+					},
+					"prefixes": {
+						"description": "Prefixes contains the prefixes exposed to the peered network",
+						"type": "array",
+						"items": {
+							"default": {},
+							"allOf": [
+								{
+									"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefixStatus"
+								}
+							]
+						}
 					},
 					"state": {
 						"description": "State represents the network peering state",
@@ -12298,6 +12322,59 @@
 							"Available",
 							"Error",
 							"Pending"
+						]
+					}
+				}
+			},
+			"com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefix": {
+				"description": "PeeringPrefixes defines prefixes to be exposed to the peered network",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the semantical name of the peering prefixes",
+						"type": "string",
+						"default": ""
+					},
+					"prefix": {
+						"description": "CIDR to be exposed to the peered network",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.common.v1alpha1.IPPrefix"
+							}
+						]
+					},
+					"prefixRef": {
+						"description": "PrefixRef is the reference to the prefix to be exposed to peered network An empty namespace indicates that the prefix resides in the same namespace as the source network.",
+						"default": {},
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
+							}
+						]
+					}
+				}
+			},
+			"com.github.ironcore-dev.ironcore.api.networking.v1alpha1.PeeringPrefixStatus": {
+				"description": "PeeringPrefixStatus lists prefixes exposed to peered network",
+				"type": "object",
+				"required": [
+					"name"
+				],
+				"properties": {
+					"name": {
+						"description": "Name is the name of the peering prefix",
+						"type": "string",
+						"default": ""
+					},
+					"prefix": {
+						"description": "CIDR exposed to the peered network",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.common.v1alpha1.IPPrefix"
+							}
 						]
 					}
 				}

--- a/internal/apis/compute/machine_types.go
+++ b/internal/apis/compute/machine_types.go
@@ -124,6 +124,8 @@ type NetworkInterfaceStatus struct {
 	VirtualIP *commonv1alpha1.IP
 	// State represents the attachment state of a NetworkInterface.
 	State NetworkInterfaceState
+	// networkInterfaceRef is the reference to the networkinterface attached to the machine
+	NetworkInterfaceRef corev1.LocalObjectReference `json:"networkInterfaceRef,omitempty"`
 	// LastStateTransitionTime is the last time the State transitioned.
 	LastStateTransitionTime *metav1.Time
 }

--- a/internal/apis/compute/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/compute/v1alpha1/zz_generated.conversion.go
@@ -883,6 +883,7 @@ func autoConvert_v1alpha1_NetworkInterfaceStatus_To_compute_NetworkInterfaceStat
 	out.IPs = *(*[]commonv1alpha1.IP)(unsafe.Pointer(&in.IPs))
 	out.VirtualIP = (*commonv1alpha1.IP)(unsafe.Pointer(in.VirtualIP))
 	out.State = compute.NetworkInterfaceState(in.State)
+	out.NetworkInterfaceRef = in.NetworkInterfaceRef
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
 	return nil
 }
@@ -898,6 +899,7 @@ func autoConvert_compute_NetworkInterfaceStatus_To_v1alpha1_NetworkInterfaceStat
 	out.IPs = *(*[]commonv1alpha1.IP)(unsafe.Pointer(&in.IPs))
 	out.VirtualIP = (*commonv1alpha1.IP)(unsafe.Pointer(in.VirtualIP))
 	out.State = v1alpha1.NetworkInterfaceState(in.State)
+	out.NetworkInterfaceRef = in.NetworkInterfaceRef
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
 	return nil
 }

--- a/internal/apis/compute/zz_generated.deepcopy.go
+++ b/internal/apis/compute/zz_generated.deepcopy.go
@@ -594,6 +594,7 @@ func (in *NetworkInterfaceStatus) DeepCopyInto(out *NetworkInterfaceStatus) {
 		in, out := &in.VirtualIP, &out.VirtualIP
 		*out = (*in).DeepCopy()
 	}
+	out.NetworkInterfaceRef = in.NetworkInterfaceRef
 	if in.LastStateTransitionTime != nil {
 		in, out := &in.LastStateTransitionTime, &out.LastStateTransitionTime
 		*out = (*in).DeepCopy()

--- a/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
+++ b/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
@@ -376,16 +376,17 @@ func (r *MachineReconciler) convertIRINetworkInterfaceState(state iri.NetworkInt
 	return "", fmt.Errorf("unknown network interface attachment state %v", state)
 }
 
-func (r *MachineReconciler) convertIRINetworkInterfaceStatus(status *iri.NetworkInterfaceStatus) (computev1alpha1.NetworkInterfaceStatus, error) {
+func (r *MachineReconciler) convertIRINetworkInterfaceStatus(status *iri.NetworkInterfaceStatus, machine *computev1alpha1.Machine, machineNic computev1alpha1.NetworkInterface) (computev1alpha1.NetworkInterfaceStatus, error) {
 	state, err := r.convertIRINetworkInterfaceState(status.State)
 	if err != nil {
 		return computev1alpha1.NetworkInterfaceStatus{}, err
 	}
 
 	return computev1alpha1.NetworkInterfaceStatus{
-		Name:   status.Name,
-		Handle: status.Handle,
-		State:  state,
+		Name:                status.Name,
+		Handle:              status.Handle,
+		State:               state,
+		NetworkInterfaceRef: corev1.LocalObjectReference{Name: computev1alpha1.MachineNetworkInterfaceName(machine.Name, machineNic)},
 	}, nil
 }
 
@@ -394,6 +395,7 @@ func (r *MachineReconciler) addNetworkInterfaceStatusValues(now metav1.Time, exi
 		existing.LastStateTransitionTime = &now
 	}
 	existing.Name = newValues.Name
+	existing.NetworkInterfaceRef = newValues.NetworkInterfaceRef
 	existing.State = newValues.State
 	existing.Handle = newValues.Handle
 }
@@ -417,14 +419,15 @@ func (r *MachineReconciler) getNetworkInterfaceStatusesForMachine(
 		)
 		if ok {
 			var err error
-			nicStatusValues, err = r.convertIRINetworkInterfaceStatus(iriNicStatus)
+			nicStatusValues, err = r.convertIRINetworkInterfaceStatus(iriNicStatus, machine, machineNic)
 			if err != nil {
 				return nil, fmt.Errorf("[network interface %s] %w", machineNic.Name, err)
 			}
 		} else {
 			nicStatusValues = computev1alpha1.NetworkInterfaceStatus{
-				Name:  machineNic.Name,
-				State: computev1alpha1.NetworkInterfaceStatePending,
+				Name:                machineNic.Name,
+				State:               computev1alpha1.NetworkInterfaceStatePending,
+				NetworkInterfaceRef: corev1.LocalObjectReference{Name: computev1alpha1.MachineNetworkInterfaceName(machine.Name, machineNic)},
 			}
 		}
 


### PR DESCRIPTION
# Proposed Changes

- Add `NetworkInterfaceRef`of type `corev1.LocalObjectReference` to `Machine.Status.NetworkInterfaceStatus` struct for identifying the claimed `NetworkInterface`
- Update logic to set claimed `NetworkInterfaceRef` in `machinepoollet`
- Add test cases

Fixes #1117 