### PR TITLE
Fix flapping IPs in NetworkInterface status

### DIFF
--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -54,7 +54,7 @@ var (
 const (
 	eventuallyTimeout    = 3 * time.Second
 	pollingInterval      = 50 * time.Millisecond
-	consistentlyDuration = 1 * time.Second
+	consistentlyDuration = 10 * time.Second
 	apiServiceTimeout    = 5 * time.Minute
 
 	controllerManagerService = "controller-manager"

--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -54,7 +54,7 @@ var (
 const (
 	eventuallyTimeout    = 3 * time.Second
 	pollingInterval      = 50 * time.Millisecond
-	consistentlyDuration = 10 * time.Second
+	consistentlyDuration = 3 * time.Second
 	apiServiceTimeout    = 5 * time.Minute
 
 	controllerManagerService = "controller-manager"

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -300,8 +300,13 @@ var _ = Describe("MachineController", func() {
 		}
 		srv.SetMachines([]*testingmachine.FakeMachine{iriMachine})
 
-		By("waiting for the ironcore network interface to have a provider id set")
-		Eventually(Object(nic)).Should(HaveField("Spec.ProviderID", Equal("primary-handle")))
+		Eventually(Object(nic)).Should(And(
+			HaveField("Spec.ProviderID", Equal("primary-handle")),
+			HaveField("Status", MatchFields(IgnoreExtras, Fields{
+				"State": Equal(networkingv1alpha1.NetworkInterfaceStateAvailable),
+				"IPs":   ContainElement(commonv1alpha1.MustParseIP("10.0.0.1")),
+			})),
+		))
 
 		Consistently(Object(nic)).Should(
 			HaveField("Status", MatchFields(IgnoreExtras, Fields{

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -301,13 +301,14 @@ var _ = Describe("MachineController", func() {
 		srv.SetMachines([]*testingmachine.FakeMachine{iriMachine})
 
 		By("waiting for the ironcore network interface to have a provider id set")
-		Eventually(Object(nic)).Should(And(
-			HaveField("Spec.ProviderID", Equal("primary-handle")),
+		Eventually(Object(nic)).Should(HaveField("Spec.ProviderID", Equal("primary-handle")))
+
+		Consistently(Object(nic)).Should(
 			HaveField("Status", MatchFields(IgnoreExtras, Fields{
 				"State": Equal(networkingv1alpha1.NetworkInterfaceStateAvailable),
 				"IPs":   ContainElement(commonv1alpha1.MustParseIP("10.0.0.1")),
 			})),
-		))
+		)
 
 		By("ensuring the ironcore machine status networkInterfaces to have correct NetworkInterfaceRef")
 		Eventually(Object(machine)).Should(HaveField("Status.NetworkInterfaces", ConsistOf(MatchFields(IgnoreExtras, Fields{


### PR DESCRIPTION
# Proposed Changes

- Update `NetworkInterface` status only when there is change in `State` or list of `IPs`


Fixes #1111 