### PR TITLE
Implemented a split client for `*-brokers`

### DIFF
--- a/broker/bucketbroker/cmd/bucketbroker/app/app.go
+++ b/broker/bucketbroker/cmd/bucketbroker/app/app.go
@@ -85,7 +85,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("error getting config: %w", err)
 	}
 
-	srv, err := server.New(cfg, server.Options{
+	srv, err := server.New(ctx, cfg, server.Options{
 		Namespace:          opts.Namespace,
 		BucketPoolName:     opts.BucketPoolName,
 		BucketPoolSelector: opts.BucketPoolSelector,

--- a/broker/bucketbroker/server/bucket_create_test.go
+++ b/broker/bucketbroker/server/bucket_create_test.go
@@ -10,7 +10,6 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	bucketpoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/bucketpoollet/api/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -35,7 +34,6 @@ var _ = Describe("CreateBucket", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).NotTo(BeNil())
 

--- a/broker/bucketbroker/server/bucket_delete_test.go
+++ b/broker/bucketbroker/server/bucket_delete_test.go
@@ -8,11 +8,10 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	bucketpoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/bucketpoollet/api/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("DeleteBucket", func() {
@@ -33,7 +32,6 @@ var _ = Describe("DeleteBucket", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createRes).NotTo(BeNil())
 

--- a/broker/bucketbroker/server/bucket_list.go
+++ b/broker/bucketbroker/server/bucket_list.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -117,22 +116,15 @@ func (s *Server) aggregateIronCoreBucket(
 }
 
 func (s *Server) getIronCoreBucket(ctx context.Context, id string) (*storagev1alpha1.Bucket, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("entered get IronCore Bucket")
 	ironcoreBucket := &storagev1alpha1.Bucket{}
 	ironcoreBucketKey := client.ObjectKey{Namespace: s.namespace, Name: id}
-	log.V(1).Info("get bucket")
 	if err := s.client.Get(ctx, ironcoreBucketKey, ironcoreBucket); err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.V(1).Info("got error during get")
 			return nil, fmt.Errorf("error getting ironcore bucket %s: %w", id, err)
 		}
-		log.V(1).Info("found no bucket")
 		return nil, status.Errorf(codes.NotFound, "bucket %s not found", id)
 	}
-	log.V(1).Info("got bucket")
 	if !apiutils.IsManagedBy(ironcoreBucket, bucketbrokerv1alpha1.BucketBrokerManager) || !apiutils.IsCreated(ironcoreBucket) {
-		log.V(1).Info("not managed")
 		return nil, status.Errorf(codes.NotFound, "bucket %s not found", id)
 	}
 	return ironcoreBucket, nil

--- a/broker/bucketbroker/server/bucketclass_list_test.go
+++ b/broker/bucketbroker/server/bucketclass_list_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 var _ = Describe("ListBucketClasses", func() {
-
 	_, bucketPool, srv := SetupTest()
 	bucketClass1 := SetupBucketClass("100Mi", "100")
 	bucketClass2 := SetupBucketClass("200Mi", "200")

--- a/broker/bucketbroker/server/event_list.go
+++ b/broker/bucketbroker/server/event_list.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"fmt"
 
+	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
+	"github.com/ironcore-dev/ironcore/broker/bucketbroker/apiutils"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
+	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
-	"github.com/ironcore-dev/ironcore/broker/bucketbroker/apiutils"
-	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
-	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
 )
 
 const (
@@ -42,7 +42,7 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	for _, bucketEvent := range bucketEventList.Items {
 		ironcoreBucket, err := s.getIronCoreBucket(ctx, bucketEvent.InvolvedObject.Name)
 		if err != nil {
-			log.V(1).Info("Unable to get ironcore bucket", "BucketName", bucketEvent.InvolvedObject.Name)
+			log.Error(err, "Unable to get ironcore bucket", "BucketName", bucketEvent.InvolvedObject.Name)
 			continue
 		}
 		bucketObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreBucket.ObjectMeta)

--- a/broker/bucketbroker/server/event_list.go
+++ b/broker/bucketbroker/server/event_list.go
@@ -27,34 +27,28 @@ const (
 
 func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(1).Info("entered listEvents")
 	bucketEventList := &v1.EventList{}
 	selectorField := fields.Set{
 		InvolvedObjectKindSelector:       InvolvedObjectKind,
 		InvolvedObjectAPIVersionSelector: storagev1alpha1.SchemeGroupVersion.String(),
 	}
 
-	log.V(1).Info("listing bucket events")
 	if err := s.client.List(ctx, bucketEventList,
 		client.InNamespace(s.namespace), client.MatchingFieldsSelector{Selector: selectorField.AsSelector()},
 	); err != nil {
 		return nil, err
 	}
 
-	log.V(1).Info("got events", "amount", len(bucketEventList.Items))
 	var iriEvents []*irievent.Event
 	for _, bucketEvent := range bucketEventList.Items {
-		log.V(1).Info("get ironcore bucket")
 		ironcoreBucket, err := s.getIronCoreBucket(ctx, bucketEvent.InvolvedObject.Name)
 		if err != nil {
-			log.V(1).Info("error occurred getting ironcore bucket")
 			log.Error(err, "Unable to get ironcore bucket", "BucketName", bucketEvent.InvolvedObject.Name)
 			continue
 		}
-		log.V(1).Info("got buckets")
 		bucketObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreBucket.ObjectMeta)
 		if err != nil {
-			log.V(1).Info("error occurred getting object metadata")
+			log.Error(err, "Unable to get ironcore bucket object metadata", "BucketName", bucketEvent.InvolvedObject.Name)
 			continue
 		}
 		iriEvent := &irievent.Event{
@@ -68,8 +62,6 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 		}
 		iriEvents = append(iriEvents, iriEvent)
 	}
-
-	log.V(1).Info("produced iri events", "amount", len(iriEvents))
 	return iriEvents, nil
 }
 

--- a/broker/bucketbroker/server/event_list_test.go
+++ b/broker/bucketbroker/server/event_list_test.go
@@ -11,21 +11,19 @@ import (
 	"github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	bucketpoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/bucketpoollet/api/v1alpha1"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ListEvents", func() {
 	ns, _, srv := SetupTest()
 	bucketClass := SetupBucketClass("250Mi", "1500")
 
-	FIt("should correctly list events", func(ctx SpecContext) {
+	It("should correctly list events", func(ctx SpecContext) {
 		Expect(storagev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 		k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme: scheme.Scheme,
@@ -45,7 +43,6 @@ var _ = Describe("ListEvents", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).NotTo(BeNil())
 

--- a/broker/bucketbroker/server/event_list_test.go
+++ b/broker/bucketbroker/server/event_list_test.go
@@ -11,20 +11,21 @@ import (
 	"github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	bucketpoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/bucketpoollet/api/v1alpha1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ListEvents", func() {
 	ns, _, srv := SetupTest()
 	bucketClass := SetupBucketClass("250Mi", "1500")
 
-	It("should correctly list events", func(ctx SpecContext) {
+	FIt("should correctly list events", func(ctx SpecContext) {
 		Expect(storagev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 		k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme: scheme.Scheme,

--- a/broker/bucketbroker/server/server.go
+++ b/broker/bucketbroker/server/server.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var scheme = runtime.NewScheme()
@@ -111,8 +112,10 @@ var _ iri.BucketRuntimeServer = (*Server)(nil)
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 
 func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
+	log := log.FromContext(ctx)
+	log.Info("entered server.New")
 	setOptionsDefaults(&opts)
-
+	log.Info("create cache")
 	readCache, err := cache.New(cfg, cache.Options{
 		Scheme: scheme,
 		DefaultNamespaces: map[string]cache.Config{
@@ -123,15 +126,22 @@ func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 		return nil, fmt.Errorf("error creating cache: %w", err)
 	}
 
-	go func() {
-		if err := readCache.Start(ctx); err != nil {
-			fmt.Printf("Error starting cache: %v\n", err)
-		}
-	}()
+	log.Info("start cache")
+	// go func() {
+	if err := readCache.Start(ctx); err != nil {
+		log.Info("error starting cache")
+		fmt.Printf("Error starting cache: %v\n", err)
+	}
+	log.Info("started cache")
+	// }()
+
+	log.Info("syncing cache")
 	if !readCache.WaitForCacheSync(ctx) {
+		log.Info("timeout waiting for cache sync")
 		return nil, fmt.Errorf("failed to sync cache")
 	}
 
+	log.Info("creating client")
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
 		Cache: &client.CacheOptions{
@@ -143,6 +153,7 @@ func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
+	log.Info("returning server obj")
 	return &Server{
 		client:             c,
 		namespace:          opts.Namespace,

--- a/broker/bucketbroker/server/server.go
+++ b/broker/bucketbroker/server/server.go
@@ -22,6 +22,7 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -134,7 +135,8 @@ func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
 		Cache: &client.CacheOptions{
-			Reader: readCache,
+			Reader:     readCache,
+			DisableFor: []client.Object{&v1.Event{}},
 		},
 	})
 	if err != nil {

--- a/broker/bucketbroker/server/server.go
+++ b/broker/bucketbroker/server/server.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
+
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -19,6 +20,7 @@ import (
 	"github.com/ironcore-dev/ironcore/broker/bucketbroker/apiutils"
 	"github.com/ironcore-dev/ironcore/broker/common/cleaner"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,6 +29,7 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -106,11 +109,33 @@ var _ iri.BucketRuntimeServer = (*Server)(nil)
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 
-func New(cfg *rest.Config, opts Options) (*Server, error) {
+func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 	setOptionsDefaults(&opts)
+
+	readCache, err := cache.New(cfg, cache.Options{
+		Scheme: scheme,
+		DefaultNamespaces: map[string]cache.Config{
+			opts.Namespace: {},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating cache: %w", err)
+	}
+
+	go func() {
+		if err := readCache.Start(ctx); err != nil {
+			fmt.Printf("Error starting cache: %v\n", err)
+		}
+	}()
+	if !readCache.WaitForCacheSync(ctx) {
+		return nil, fmt.Errorf("failed to sync cache")
+	}
 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
+		Cache: &client.CacheOptions{
+			Reader: readCache,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)

--- a/broker/bucketbroker/server/server.go
+++ b/broker/bucketbroker/server/server.go
@@ -127,13 +127,13 @@ func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 	}
 
 	log.Info("start cache")
-	// go func() {
-	if err := readCache.Start(ctx); err != nil {
-		log.Info("error starting cache")
-		fmt.Printf("Error starting cache: %v\n", err)
-	}
-	log.Info("started cache")
-	// }()
+	go func() {
+		if err := readCache.Start(ctx); err != nil {
+			log.Info("error starting cache")
+			fmt.Printf("Error starting cache: %v\n", err)
+		}
+		log.Info("started cache")
+	}()
 
 	log.Info("syncing cache")
 	if !readCache.WaitForCacheSync(ctx) {

--- a/broker/bucketbroker/server/server_suite_test.go
+++ b/broker/bucketbroker/server/server_suite_test.go
@@ -123,7 +123,9 @@ func SetupTest() (*corev1.Namespace, *storagev1alpha1.BucketPool, *server.Server
 		Expect(k8sClient.Create(ctx, bucketPool)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, bucketPool)
 
-		newSrv, err := server.New(ctx, cfg, server.Options{
+		srvCtx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+		newSrv, err := server.New(srvCtx, cfg, server.Options{
 			Namespace:      ns.Name,
 			BucketPoolName: bucketPool.Name,
 			BucketPoolSelector: map[string]string{

--- a/broker/bucketbroker/server/server_suite_test.go
+++ b/broker/bucketbroker/server/server_suite_test.go
@@ -8,15 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ironcore-dev/controller-utils/buildutils"
-	"github.com/ironcore-dev/controller-utils/modutils"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/bucketbroker/server"
 	utilsenvtest "github.com/ironcore-dev/ironcore/utils/envtest"
 	"github.com/ironcore-dev/ironcore/utils/envtest/apiserver"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+
+	"github.com/ironcore-dev/controller-utils/buildutils"
+	"github.com/ironcore-dev/controller-utils/modutils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,9 +23,12 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var (
@@ -121,7 +123,7 @@ func SetupTest() (*corev1.Namespace, *storagev1alpha1.BucketPool, *server.Server
 		Expect(k8sClient.Create(ctx, bucketPool)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, bucketPool)
 
-		newSrv, err := server.New(cfg, server.Options{
+		newSrv, err := server.New(ctx, cfg, server.Options{
 			Namespace:      ns.Name,
 			BucketPoolName: bucketPool.Name,
 			BucketPoolSelector: map[string]string{

--- a/broker/machinebroker/cluster/cluster.go
+++ b/broker/machinebroker/cluster/cluster.go
@@ -4,6 +4,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
@@ -11,10 +12,12 @@ import (
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/common/idgen"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubernetes "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,11 +63,33 @@ func setOptionsDefaults(o *Options) {
 	}
 }
 
-func New(cfg *rest.Config, namespace string, opts Options) (Cluster, error) {
+func New(ctx context.Context, cfg *rest.Config, namespace string, opts Options) (Cluster, error) {
 	setOptionsDefaults(&opts)
+
+	readCache, err := cache.New(cfg, cache.Options{
+		Scheme: scheme,
+		DefaultNamespaces: map[string]cache.Config{
+			namespace: {},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating cache: %w", err)
+	}
+
+	go func() {
+		if err := readCache.Start(ctx); err != nil {
+			fmt.Printf("Error starting cache: %v\n", err)
+		}
+	}()
+	if !readCache.WaitForCacheSync(ctx) {
+		return nil, fmt.Errorf("failed to sync cache")
+	}
 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
+		Cache: &client.CacheOptions{
+			Reader: readCache,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)

--- a/broker/machinebroker/cluster/cluster.go
+++ b/broker/machinebroker/cluster/cluster.go
@@ -13,6 +13,7 @@ import (
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/common/idgen"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubernetes "k8s.io/client-go/kubernetes/scheme"
@@ -88,7 +89,8 @@ func New(ctx context.Context, cfg *rest.Config, namespace string, opts Options) 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
 		Cache: &client.CacheOptions{
-			Reader: readCache,
+			Reader:     readCache,
+			DisableFor: []client.Object{&v1.Event{}},
 		},
 	})
 	if err != nil {

--- a/broker/machinebroker/cmd/machinebroker/app/app.go
+++ b/broker/machinebroker/cmd/machinebroker/app/app.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ironcore-dev/ironcore/broker/common"
 	commongrpc "github.com/ironcore-dev/ironcore/broker/common/grpc"
+	machinebrokerconfig "github.com/ironcore-dev/ironcore/broker/machinebroker/client/config"
 	machinebrokerhttp "github.com/ironcore-dev/ironcore/broker/machinebroker/http"
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/server"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
@@ -89,7 +90,7 @@ func Run(ctx context.Context, opts Options) error {
 	log := ctrl.LoggerFrom(ctx)
 	setupLog := log.WithName("setup")
 
-	getter, err := mchinebrokerconfig.NewGetter()
+	getter, err := machinebrokerconfig.NewGetter()
 	if err != nil {
 		return fmt.Errorf("error creating new getter: %w", err)
 	}

--- a/broker/machinebroker/cmd/machinebroker/app/app.go
+++ b/broker/machinebroker/cmd/machinebroker/app/app.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/ironcore-dev/ironcore/broker/common"
 	commongrpc "github.com/ironcore-dev/ironcore/broker/common/grpc"
-	mchinebrokerconfig "github.com/ironcore-dev/ironcore/broker/machinebroker/client/config"
 	machinebrokerhttp "github.com/ironcore-dev/ironcore/broker/machinebroker/http"
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/server"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
@@ -121,7 +120,7 @@ func Run(ctx context.Context, opts Options) error {
 		"BrokerDownwardAPILabels", opts.BrokerDownwardAPILabels,
 	)
 
-	srv, err := server.New(cfg, opts.Namespace, server.Options{
+	srv, err := server.New(ctx, cfg, opts.Namespace, server.Options{
 		BaseURL:                 baseURL,
 		BrokerDownwardAPILabels: opts.BrokerDownwardAPILabels,
 		MachinePoolName:         opts.MachinePoolName,

--- a/broker/machinebroker/server/event_list.go
+++ b/broker/machinebroker/server/event_list.go
@@ -47,6 +47,7 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 		}
 		machineObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreMachine.ObjectMeta)
 		if err != nil {
+			log.Error(err, "Unable to get ironcore machine object metadata", "MachineName", machineEvent.InvolvedObject.Name)
 			continue
 		}
 		iriEvent := &irievent.Event{

--- a/broker/machinebroker/server/event_list.go
+++ b/broker/machinebroker/server/event_list.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"fmt"
 
+	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
+	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
+	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
-	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
-	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
-	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 )
 
 const (
@@ -42,7 +42,7 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	for _, machineEvent := range machineEventList.Items {
 		ironcoreMachine, err := s.getIronCoreMachine(ctx, machineEvent.InvolvedObject.Name)
 		if err != nil {
-			log.V(1).Info("Unable to get ironcore machine", "MachineName", machineEvent.InvolvedObject.Name)
+			log.Error(err, "Unable to get ironcore machine", "MachineName", machineEvent.InvolvedObject.Name)
 			continue
 		}
 		machineObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreMachine.ObjectMeta)

--- a/broker/machinebroker/server/event_list_test.go
+++ b/broker/machinebroker/server/event_list_test.go
@@ -14,7 +14,6 @@ import (
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/broker/machinebroker/server/server.go
+++ b/broker/machinebroker/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/cluster"
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/networks"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+
 	"k8s.io/client-go/rest"
 )
 
@@ -64,13 +65,13 @@ type Options struct {
 	MachinePoolSelector     map[string]string
 }
 
-func New(cfg *rest.Config, namespace string, opts Options) (*Server, error) {
+func New(ctx context.Context, cfg *rest.Config, namespace string, opts Options) (*Server, error) {
 	baseURL, err := url.ParseRequestURI(opts.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url %q: %w", opts.BaseURL, err)
 	}
 
-	c, err := cluster.New(cfg, namespace, cluster.Options{
+	c, err := cluster.New(ctx, cfg, namespace, cluster.Options{
 		MachinePoolName:     opts.MachinePoolName,
 		MachinePoolSelector: opts.MachinePoolSelector,
 	})
@@ -91,7 +92,7 @@ func (s *Server) Start(ctx context.Context) error {
 	return s.networks.Start(ctx)
 }
 
-func (s *Server) buildURL(method string, token string) string {
+func (s *Server) buildURL(method, token string) string {
 	return s.baseURL.ResolveReference(&url.URL{
 		Path: path.Join(method, token),
 	}).String()

--- a/broker/machinebroker/server/server_suite_test.go
+++ b/broker/machinebroker/server/server_suite_test.go
@@ -124,15 +124,15 @@ func SetupTest() (*corev1.Namespace, *server.Server) {
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "failed to create test namespace")
 		DeferCleanup(k8sClient.Delete, ns)
 
-		newSrv, err := server.New(ctx, cfg, ns.Name, server.Options{
+		srvCtx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+		newSrv, err := server.New(srvCtx, cfg, ns.Name, server.Options{
 			BaseURL: baseURL,
 			BrokerDownwardAPILabels: map[string]string{
 				"root-machine-uid": machinepoolletv1alpha1.MachineUIDLabel,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		srvCtx, cancel := context.WithCancel(context.Background())
-		DeferCleanup(cancel)
 		go func() {
 			defer GinkgoRecover()
 			Expect(newSrv.Start(srvCtx)).To(Succeed())

--- a/broker/machinebroker/server/server_suite_test.go
+++ b/broker/machinebroker/server/server_suite_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ironcore-dev/controller-utils/buildutils"
-	"github.com/ironcore-dev/controller-utils/modutils"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
@@ -19,8 +17,9 @@ import (
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	utilsenvtest "github.com/ironcore-dev/ironcore/utils/envtest"
 	"github.com/ironcore-dev/ironcore/utils/envtest/apiserver"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+
+	"github.com/ironcore-dev/controller-utils/buildutils"
+	"github.com/ironcore-dev/controller-utils/modutils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +27,12 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var (
@@ -122,7 +124,7 @@ func SetupTest() (*corev1.Namespace, *server.Server) {
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed(), "failed to create test namespace")
 		DeferCleanup(k8sClient.Delete, ns)
 
-		newSrv, err := server.New(cfg, ns.Name, server.Options{
+		newSrv, err := server.New(ctx, cfg, ns.Name, server.Options{
 			BaseURL: baseURL,
 			BrokerDownwardAPILabels: map[string]string{
 				"root-machine-uid": machinepoolletv1alpha1.MachineUIDLabel,

--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -13,12 +13,11 @@ import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
-	volumebrokerconfig "github.com/ironcore-dev/ironcore/broker/bucketbroker/client/config"
 	"github.com/ironcore-dev/ironcore/broker/common"
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/server"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/client/config"
 
+	"github.com/ironcore-dev/controller-utils/configutils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -85,7 +84,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("error getting config: %w", err)
 	}
 
-	srv, err := server.New(cfg, server.Options{
+	srv, err := server.New(ctx, cfg, server.Options{
 		Namespace:          opts.Namespace,
 		VolumePoolName:     opts.VolumePoolName,
 		VolumePoolSelector: opts.VolumePoolSelector,

--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -13,11 +13,12 @@ import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
+	volumebrokerconfig "github.com/ironcore-dev/ironcore/broker/bucketbroker/client/config"
 	"github.com/ironcore-dev/ironcore/broker/common"
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/server"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/ironcore/utils/client/config"
 
-	"github.com/ironcore-dev/controller-utils/configutils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )

--- a/broker/volumebroker/server/event_list.go
+++ b/broker/volumebroker/server/event_list.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"fmt"
 
+	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
+	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
+	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
-	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
-	irievent "github.com/ironcore-dev/ironcore/iri/apis/event/v1alpha1"
-	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 )
 
 const (
@@ -47,6 +47,7 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 		}
 		volumeObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreVolume.ObjectMeta)
 		if err != nil {
+			log.Error(err, "Unable to get ironcore volume object metadata", "VolumeName", volumeEvent.InvolvedObject.Name)
 			continue
 		}
 		iriEvent := &irievent.Event{

--- a/broker/volumebroker/server/event_list.go
+++ b/broker/volumebroker/server/event_list.go
@@ -42,7 +42,7 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	for _, volumeEvent := range volumeEventList.Items {
 		ironcoreVolume, err := s.getIronCoreVolume(ctx, volumeEvent.InvolvedObject.Name)
 		if err != nil {
-			log.V(1).Info("Unable to get ironcore volume", "VolumeName", volumeEvent.InvolvedObject.Name)
+			log.Error(err, "Unable to get ironcore volume", "VolumeName", volumeEvent.InvolvedObject.Name)
 			continue
 		}
 		volumeObjectMetadata, err := apiutils.GetObjectMetadata(&ironcoreVolume.ObjectMeta)

--- a/broker/volumebroker/server/event_list_test.go
+++ b/broker/volumebroker/server/event_list_test.go
@@ -14,7 +14,6 @@ import (
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,7 +48,6 @@ var _ = Describe("ListEvents", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).NotTo(BeNil())
 

--- a/broker/volumebroker/server/server.go
+++ b/broker/volumebroker/server/server.go
@@ -20,6 +20,7 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -120,7 +121,8 @@ func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
 		Cache: &client.CacheOptions{
-			Reader: readCache,
+			Reader:     readCache,
+			DisableFor: []client.Object{&v1.Event{}},
 		},
 	})
 	if err != nil {

--- a/broker/volumebroker/server/server.go
+++ b/broker/volumebroker/server/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -17,6 +18,7 @@ import (
 	volumebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/volumebroker/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +27,7 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -92,11 +95,33 @@ var _ iri.VolumeRuntimeServer = (*Server)(nil)
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumes,verbs=get;list;watch;create;update;patch;delete
 
-func New(cfg *rest.Config, opts Options) (*Server, error) {
+func New(ctx context.Context, cfg *rest.Config, opts Options) (*Server, error) {
 	setOptionsDefaults(&opts)
+
+	readCache, err := cache.New(cfg, cache.Options{
+		Scheme: scheme,
+		DefaultNamespaces: map[string]cache.Config{
+			opts.Namespace: {},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating cache: %w", err)
+	}
+
+	go func() {
+		if err := readCache.Start(ctx); err != nil {
+			fmt.Printf("Error starting cache: %v\n", err)
+		}
+	}()
+	if !readCache.WaitForCacheSync(ctx) {
+		return nil, fmt.Errorf("failed to sync cache")
+	}
 
 	c, err := client.New(cfg, client.Options{
 		Scheme: scheme,
+		Cache: &client.CacheOptions{
+			Reader: readCache,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)

--- a/broker/volumebroker/server/server_suite_test.go
+++ b/broker/volumebroker/server/server_suite_test.go
@@ -130,7 +130,9 @@ func SetupTest() (*corev1.Namespace, *server.Server) {
 		Expect(k8sClient.Create(ctx, volumePool)).To(Succeed(), "failed to create test volume pool")
 		DeferCleanup(k8sClient.Delete, volumePool)
 
-		newSrv, err := server.New(ctx, cfg, server.Options{
+		srvCtx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+		newSrv, err := server.New(srvCtx, cfg, server.Options{
 			Namespace:      ns.Name,
 			VolumePoolName: volumePool.Name,
 			VolumePoolSelector: map[string]string{

--- a/broker/volumebroker/server/server_suite_test.go
+++ b/broker/volumebroker/server/server_suite_test.go
@@ -8,16 +8,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ironcore-dev/controller-utils/buildutils"
-	"github.com/ironcore-dev/controller-utils/modutils"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/common/idgen"
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/server"
 	utilsenvtest "github.com/ironcore-dev/ironcore/utils/envtest"
 	"github.com/ironcore-dev/ironcore/utils/envtest/apiserver"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+
+	"github.com/ironcore-dev/controller-utils/buildutils"
+	"github.com/ironcore-dev/controller-utils/modutils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,9 +24,12 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
 
 var (
@@ -128,7 +130,7 @@ func SetupTest() (*corev1.Namespace, *server.Server) {
 		Expect(k8sClient.Create(ctx, volumePool)).To(Succeed(), "failed to create test volume pool")
 		DeferCleanup(k8sClient.Delete, volumePool)
 
-		newSrv, err := server.New(cfg, server.Options{
+		newSrv, err := server.New(ctx, cfg, server.Options{
 			Namespace:      ns.Name,
 			VolumePoolName: volumePool.Name,
 			VolumePoolSelector: map[string]string{

--- a/broker/volumebroker/server/volume_create_test.go
+++ b/broker/volumebroker/server/volume_create_test.go
@@ -10,7 +10,6 @@ import (
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -38,7 +37,6 @@ var _ = Describe("CreateVolume", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).NotTo(BeNil())
 

--- a/broker/volumebroker/server/volume_delete_test.go
+++ b/broker/volumebroker/server/volume_delete_test.go
@@ -8,11 +8,10 @@ import (
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("DeleteVolume", func() {
@@ -36,7 +35,6 @@ var _ = Describe("DeleteVolume", func() {
 				},
 			},
 		})
-
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createRes).NotTo(BeNil())
 

--- a/broker/volumebroker/server/volume_expand_test.go
+++ b/broker/volumebroker/server/volume_expand_test.go
@@ -9,12 +9,11 @@ import (
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ExpandVolume", func() {
@@ -32,7 +31,6 @@ var _ = Describe("ExpandVolume", func() {
 			},
 			ResizePolicy: storagev1alpha1.ResizePolicyExpandOnly,
 		}
-
 		Expect(k8sClient.Create(ctx, volumeClass)).To(Succeed(), "failed to create test volume class")
 		DeferCleanup(k8sClient.Delete, volumeClass)
 


### PR DESCRIPTION
# Proposed Changes

- Pass context (`ctx`) to server creation functions for better resource management.
- Implement an in-memory cache with namespace-specific watching for improved performance.
- Reorganize imports for readability.

Fixes #1156 