### PR TITLE
Fix IRI `*-broker` status

### DIFF
--- a/broker/bucketbroker/server/bucketclass_list.go
+++ b/broker/bucketbroker/server/bucketclass_list.go
@@ -24,6 +24,7 @@ func (s *Server) getTargetIronCoreBucketPools(ctx context.Context) ([]storagev1a
 			}
 			return nil, nil
 		}
+		return []storagev1alpha1.BucketPool{*ironcoreBucketPool}, nil
 	}
 
 	bucketPoolList := &storagev1alpha1.BucketPoolList{}

--- a/broker/machinebroker/server/status.go
+++ b/broker/machinebroker/server/status.go
@@ -27,6 +27,7 @@ func (s *Server) getTargetIronCoreMachinePools(ctx context.Context) ([]computev1
 			}
 			return nil, nil
 		}
+		return []computev1alpha1.MachinePool{*ironcoreMachinePool}, nil
 	}
 
 	machinePoolList := &computev1alpha1.MachinePoolList{}

--- a/broker/volumebroker/server/status.go
+++ b/broker/volumebroker/server/status.go
@@ -26,6 +26,7 @@ func (s *Server) getTargetIronCoreVolumePools(ctx context.Context) ([]storagev1a
 			}
 			return nil, nil
 		}
+		return []storagev1alpha1.VolumePool{*ironcoreVolumePool}, nil
 	}
 
 	volumePoolList := &storagev1alpha1.VolumePoolList{}


### PR DESCRIPTION
# Proposed Changes

This PR addresses an issue in the getTargetIronCoreMachinePools method within the broker status IRI response. Currently, the method retrieves and returns a list of all MachinePools in the cluster, even when a specific MachinePool is provided. This behavior occurs due to a missing return statement when a single MachinePool is fetched.