### PR TITLE
Fix flag declaration in `*-broker`s

### DIFF
--- a/broker/bucketbroker/cmd/bucketbroker/app/app.go
+++ b/broker/bucketbroker/cmd/bucketbroker/app/app.go
@@ -39,9 +39,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.GetConfigOptions.BindFlags(fs)
 	fs.StringVar(&o.Address, "address", "/var/run/iri-bucketbroker.sock", "Address to listen on.")
 
-	fs.Float32Var(&o.QPS, "qps", config.QPS, "Kubernetes client qps.")
-	fs.IntVar(&o.Burst, "burst", config.Burst, "Kubernetes client burst.")
-
 	fs.StringVar(&o.Namespace, "namespace", o.Namespace, "Target Kubernetes namespace to use.")
 	fs.StringVar(&o.BucketPoolName, "bucket-pool-name", o.BucketPoolName, "Name of the target bucket pool to pin buckets to, if any.")
 	fs.StringToStringVar(&o.BucketPoolSelector, "bucket-pool-selector", o.BucketPoolSelector, "Selector of the target bucket pools to pin buckets to, if any.")

--- a/broker/machinebroker/cmd/machinebroker/app/app.go
+++ b/broker/machinebroker/cmd/machinebroker/app/app.go
@@ -54,9 +54,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringToStringVar(&o.BrokerDownwardAPILabels, "broker-downward-api-label", nil, "The labels to broker via downward API. "+
 		"Example is for instance to broker \"root-machine-uid\" initially obtained via \"machinepoollet.ironcore.dev/machine-uid\".")
 
-	fs.Float32Var(&o.QPS, "qps", config.QPS, "Kubernetes client qps.")
-	fs.IntVar(&o.Burst, "burst", config.Burst, "Kubernetes client burst.")
-
 	fs.StringVar(&o.Namespace, "namespace", o.Namespace, "Target Kubernetes namespace to use.")
 	fs.StringVar(&o.MachinePoolName, "machine-pool-name", o.MachinePoolName, "Name of the target machine pool to pin machines to, if any.")
 	fs.StringToStringVar(&o.MachinePoolSelector, "machine-pool-selector", o.MachinePoolSelector, "Selector of the target machine pools to pin machines to, if any.")

--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -39,9 +39,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.GetConfigOptions.BindFlags(fs)
 	fs.StringVar(&o.Address, "address", "/var/run/iri-volumebroker.sock", "Address to listen on.")
 
-	fs.Float32Var(&o.QPS, "qps", config.QPS, "Kubernetes client qps.")
-	fs.IntVar(&o.Burst, "burst", config.Burst, "Kubernetes client burst.")
-
 	fs.StringVar(&o.Namespace, "namespace", o.Namespace, "Target Kubernetes namespace to use.")
 	fs.StringVar(&o.VolumePoolName, "volume-pool-name", o.VolumePoolName, "Name of the target volume pool to pin volumes to, if any.")
 	fs.StringToStringVar(&o.VolumePoolSelector, "volume-pool-selector", o.VolumePoolSelector, "Selector of the target volume pools to pin volumes to, if any.")

--- a/utils/client/config/config.go
+++ b/utils/client/config/config.go
@@ -47,11 +47,11 @@ const (
 	// EgressSelectorConfigFlagName is the name of the egress-selector-config flag.
 	EgressSelectorConfigFlagName = "egress-selector-config"
 
-	// QPS is the default value for allowed queries per second for a client.
-	QPS float32 = 20.0
+	// QpsConfigFlagName is the name of the qps flag.
+	QpsConfigFlagName = "qps"
 
-	// Burst is the default value for allowed burst rate for a client.
-	Burst int = 30
+	// BurstConfigFlagName is the name of the burst flag.
+	BurstConfigFlagName = "burst"
 )
 
 var log = ctrl.Log.WithName("client").WithName("config")

--- a/utils/client/config/options.go
+++ b/utils/client/config/options.go
@@ -87,8 +87,8 @@ func (o *GetConfigOptions) BindFlags(fs *pflag.FlagSet, opts ...func(*BindFlagOp
 	fs.StringVar(&o.BootstrapKubeconfig, bo.NameFunc(BootstrapKubeconfigFlagName), "", "Path to a bootstrap kubeconfig.")
 	fs.BoolVar(&o.RotateCertificates, bo.NameFunc(RotateCertificatesFlagName), false, "Whether to use automatic certificate / config rotation.")
 	fs.StringVar(&o.EgressSelectorConfig, bo.NameFunc(EgressSelectorConfigFlagName), "", "Path pointing to an egress selector config to use.")
-	fs.Float32Var(&o.QPS, "qps", QPS, "Kubernetes client qps.")
-	fs.IntVar(&o.Burst, "burst", Burst, "Kubernetes client burst.")
+	fs.Float32Var(&o.QPS, bo.NameFunc(QpsConfigFlagName), 0, "Kubernetes client qps.")
+	fs.IntVar(&o.Burst, bo.NameFunc(BurstConfigFlagName), 0, "Kubernetes client burst.")
 }
 
 // ApplyToGetConfig implements GetConfigOption.


### PR DESCRIPTION
# Proposed Changes

- `qps` and `burst` flag was twice declared: 
```
panic: machinebroker flag redefined: qps
```
