### PR TITLE
Propagate `NetworkInterface` IPs in `Machine` status

### DIFF
--- a/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
+++ b/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
@@ -382,11 +382,17 @@ func (r *MachineReconciler) convertIRINetworkInterfaceStatus(status *iri.Network
 		return computev1alpha1.NetworkInterfaceStatus{}, err
 	}
 
+	ips := make([]commonv1alpha1.IP, len(status.Ips))
+	for i, ip := range status.Ips {
+		ips[i] = commonv1alpha1.MustParseIP(ip)
+	}
+
 	return computev1alpha1.NetworkInterfaceStatus{
 		Name:                status.Name,
 		Handle:              status.Handle,
 		State:               state,
 		NetworkInterfaceRef: corev1.LocalObjectReference{Name: nicName},
+		IPs:                 ips,
 	}, nil
 }
 
@@ -398,6 +404,7 @@ func (r *MachineReconciler) addNetworkInterfaceStatusValues(now metav1.Time, exi
 	existing.NetworkInterfaceRef = newValues.NetworkInterfaceRef
 	existing.State = newValues.State
 	existing.Handle = newValues.Handle
+	existing.IPs = newValues.IPs
 }
 
 func (r *MachineReconciler) getNetworkInterfaceStatusesForMachine(

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -157,6 +157,7 @@ var _ = Describe("MachineController", func() {
 			"Handle":              Equal("primary-handle"),
 			"State":               Equal(computev1alpha1.NetworkInterfaceStateAttached),
 			"NetworkInterfaceRef": Equal(corev1.LocalObjectReference{Name: computev1alpha1.MachineEphemeralNetworkInterfaceName(machine.Name, "primary")}),
+			"IPs":                 Equal([]commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.11")}),
 		}))))
 
 		By("removing the network interface from the machine")
@@ -321,6 +322,7 @@ var _ = Describe("MachineController", func() {
 			"Handle":              Equal("primary-handle"),
 			"State":               Equal(computev1alpha1.NetworkInterfaceStateAttached),
 			"NetworkInterfaceRef": Equal(corev1.LocalObjectReference{Name: nic.Name}),
+			"IPs":                 Equal([]commonv1alpha1.IP{commonv1alpha1.MustParseIP("10.0.0.1")}),
 		}))))
 
 		By("removing the network interface from the machine")


### PR DESCRIPTION
# Proposed Changes

Add the `NetworkInterface` IPs in `Machine` status as soon as they are available and propageted by the machine runtime.

/cc @damyan @ScheererJ 