### PR TITLE
Add `NetworkPolicy` e2e test manifests with docs

### DIFF
--- a/config/samples/e2e/bases/network-policy/kustomization.yaml
+++ b/config/samples/e2e/bases/network-policy/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- network.yaml
+- machine1.yaml
+- machine2.yaml
+- network-policy.yaml

--- a/config/samples/e2e/bases/network-policy/machine1.yaml
+++ b/config/samples/e2e/bases/network-policy/machine1.yaml
@@ -1,0 +1,41 @@
+apiVersion: compute.ironcore.dev/v1alpha1
+kind: Machine
+metadata:
+  name: machine-sample1
+spec:
+  machineClassRef:
+    name: machineclass-sample
+  ignitionRef:
+    name: ignition
+    key: ignition.yaml
+  networkInterfaces:
+  - name: primary
+    ephemeral:
+      networkInterfaceTemplate:
+        metadata:
+          labels:
+            machine: "machine-sample1"
+        spec:
+          ipFamilies:
+          - IPv4
+          ips:
+          - value: 10.0.0.1
+          networkRef:
+            name: network-sample
+          virtualIP:
+            ephemeral:
+              virtualIPTemplate:
+                spec:
+                  type: Public
+                  ipFamily: IPv4
+  volumes:
+  - name: root-disk
+    ephemeral:
+      volumeTemplate:
+        spec:
+          volumeClassRef:
+            name: volumeclass-sample
+          image: gardenlinux:rootfs-image
+          resources:
+            storage: 10Gi
+

--- a/config/samples/e2e/bases/network-policy/machine2.yaml
+++ b/config/samples/e2e/bases/network-policy/machine2.yaml
@@ -1,0 +1,41 @@
+apiVersion: compute.ironcore.dev/v1alpha1
+kind: Machine
+metadata:
+  name: machine-sample2
+spec:
+  machineClassRef:
+    name: machineclass-sample
+  ignitionRef:
+    name: ignition
+    key: ignition.yaml
+  networkInterfaces:
+  - name: primary
+    ephemeral:
+      networkInterfaceTemplate:
+        metadata:
+          labels:
+            machine: "machine-sample2"
+        spec:
+          ipFamilies:
+          - IPv4
+          ips:
+          - value: 10.0.0.2
+          networkRef:
+            name: network-sample
+          virtualIP:
+            ephemeral:
+              virtualIPTemplate:
+                spec:
+                  type: Public
+                  ipFamily: IPv4
+  volumes:
+  - name: root-disk
+    ephemeral:
+      volumeTemplate:
+        spec:
+          volumeClassRef:
+            name: volumeclass-sample
+          image: gardenlinux:rootfs-image
+          resources:
+            storage: 10Gi
+

--- a/config/samples/e2e/bases/network-policy/network-policy.yaml
+++ b/config/samples/e2e/bases/network-policy/network-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: NetworkPolicy
+metadata:
+  name: my-networkpolicy
+spec:
+  networkRef:
+    name: network-sample
+  networkInterfaceSelector:
+    matchLabels:
+      nic: machine-sample2
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - objectSelector:
+        kind: NetworkInterface
+        matchLabels:
+          nic: machine-sample1
+    ports:
+    - endPort: 22
+      port: 22
+      protocol: TCP

--- a/config/samples/e2e/bases/network-policy/network.yaml
+++ b/config/samples/e2e/bases/network-policy/network.yaml
@@ -1,0 +1,4 @@
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: Network
+metadata:
+  name: network-sample

--- a/config/samples/e2e/network-policy/README.md
+++ b/config/samples/e2e/network-policy/README.md
@@ -1,0 +1,52 @@
+# Network Policy Sample deployement
+
+This example deploys one `Network`, two `Machines` referring this `Network` and one `NetworkPolicy`.
+A `networkPolicy` object will be created with Ingress rules to allow ssh at port 22 from the other machine.
+The following artifacts will be deployed in your namespace:   
+- IronCore `Network`, `NetworkInterface` and `VirtualIP`
+- IronCore `Machine` 
+- IronCore `Volume`
+- Ironcore `NetworkPolicy`
+- Secret containing the `ignition`
+
+## Prerequisites
+
+- [Butane](https://coreos.github.io/butane/)
+
+## Usage
+1. Adapt the `namespace` in `kustomization.yaml`
+2. Replace `your-user`, `your-pw-hash` and `your-ssh-key`s in the `ignition/ignition.yaml`
+3. Run `ignition/regenerate-ignition.sh`
+4. Create the below `patch-machine.yaml` in `network-policy` folder with the desired `machineClassRef`, `machinePoolRef`, `volumeClassRef`, `volumePoolRef`, `image` etc. as per your environment
+
+```
+apiVersion: compute.ironcore.dev/v1alpha1
+kind: Machine
+metadata:
+  name: machine-sample
+spec:
+  machineClassRef:
+    name: new-machineClass
+  machinePoolRef:
+    name: new-machinePool
+  volumes:
+  - name: root-disk
+    ephemeral:
+      volumeTemplate:
+        spec:
+          volumeClassRef:
+            name: new-volumeClass
+          volumePoolRef:
+            name: new-volumePool
+          image: gardenlinux:rootfs-dev-20231025
+          resources:
+            storage: 15Gi
+```
+
+5. Update the `kustomization.yaml` with below content
+```
+patches:
+- path: patch-machine.yaml
+```
+
+6. Run (`kubectl apply -k ./`) 

--- a/config/samples/e2e/network-policy/kustomization.yaml
+++ b/config/samples/e2e/network-policy/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test
+
+resources:
+- ../bases/ignition
+- ../bases/network-policy


### PR DESCRIPTION
- Add example manifests to deploy `network-policy` which allows ssh at port 22 from the other machine

Fixes #1129 