### PR TITLE
Add missing RBAC permissions to the `apiserver_role.yaml`

### DIFF
--- a/config/apiserver/rbac/apiserver_role.yaml
+++ b/config/apiserver/rbac/apiserver_role.yaml
@@ -31,6 +31,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
     verbs:
       - get
       - list


### PR DESCRIPTION
- Add missing RBAC to the ironcore apiserver

Fixes #1204 