### PR TITLE
Add documentation for `storage` API resources

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,17 +1,17 @@
-# Installing IronCore
+# Installing Ironcore
 
 ## Requirements
 
 * `go` >= 1.20
-* `git`, `make` and `kubectl`
+* `git`, `make`, and `kubectl`
 * [Kustomize](https://kustomize.io/)
 * Access to a Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/), [kind](https://kind.sigs.k8s.io/) or a real cluster)
 
 ## Clone the Repository
 
-To bring up and install the `ironcore` project, you first need to clone the repository.
+To bring up and install the `Ironcore` project, you first need to clone the repository.
 
-```shell
+``` shell
 git clone git@github.com:ironcore-dev/ironcore.git
 cd ironcore
 ```
@@ -20,41 +20,41 @@ cd ironcore
 
 If there is no [cert-manager](https://cert-manager.io/docs/) present in the cluster it needs to be installed.
 
-```shell
+``` shell
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
 ```
 
 ## Install APIs into the Cluster
 
-Your Kubernetes API server needs to know about the APIs which come with the `ironcore` project. To install the APIs into your cluster, run
+Your Kubernetes API server needs to know about the APIs that come with the `Ironcore` project. To install the APIs into your cluster, run
 
-```shell
+``` shell
 make install
 ```
 
-**Note**: This requires the `APISERVER_IMG` (Makefile default set to `apiserver`) to be pullable from your kubernetes
-cluster. For local development with `kind`, a make target that builds and loads the api server image and then applies
+**Note**: This requires the `APISERVER_IMG` (Makefile default set to `apiserver`) to be pullable from your Kubernetes
+cluster. For local development with `kind`, a make target that builds and loads the API server image and then applies
 the manifests is available via
 
-```shell
+``` shell
 make kind-install
 ```
 
-**Note**: In case that there are multiple environments running, ensure that `kind get clusters` is pointing to the
+**Note**: In case multiple environments running, ensure that `kind get clusters` is pointing to the
 default kind cluster.
 
 ## Deploy the Controller Manager
 
-The controller manager can be started via the following command
+The controller manager can be started via the following command.
 
-```shell
+``` shell
 make kind-deploy
 ```
-## validate
+## Validate
 
-Make sure you have all the below pods running
+Make sure you have all the below pods running.
 
-```shell
+``` shell
 $ kubectl get po -n ironcore-system
 NAME                                           READY   STATUS    RESTARTS       AGE
 ironcore-apiserver-85995846f9-47247            1/1     Running   0              136m
@@ -67,14 +67,14 @@ ironcore-etcd-0                                1/1     Running   0              
 The `config/samples` folder contains samples for all APIs supported by this project. You can apply any of the samples by
 running
 
-```shell
+``` shell
 kubectl apply -f config/samples/SOME_RESOURCE.yaml
 ```
 
 ## Cleanup
 
-To remove the APIs from your cluster, simply run
+To remove the APIs from your cluster, simply run.
 
-```shell
+``` shell
 make uninstall
 ```

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,1 +1,80 @@
 # Installing IronCore
+
+## Requirements
+
+* `go` >= 1.20
+* `git`, `make` and `kubectl`
+* [Kustomize](https://kustomize.io/)
+* Access to a Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/), [kind](https://kind.sigs.k8s.io/) or a real cluster)
+
+## Clone the Repository
+
+To bring up and install the `ironcore` project, you first need to clone the repository.
+
+```shell
+git clone git@github.com:ironcore-dev/ironcore.git
+cd ironcore
+```
+
+## Install cert-manager
+
+If there is no [cert-manager](https://cert-manager.io/docs/) present in the cluster it needs to be installed.
+
+```shell
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+```
+
+## Install APIs into the Cluster
+
+Your Kubernetes API server needs to know about the APIs which come with the `ironcore` project. To install the APIs into your cluster, run
+
+```shell
+make install
+```
+
+**Note**: This requires the `APISERVER_IMG` (Makefile default set to `apiserver`) to be pullable from your kubernetes
+cluster. For local development with `kind`, a make target that builds and loads the api server image and then applies
+the manifests is available via
+
+```shell
+make kind-install
+```
+
+**Note**: In case that there are multiple environments running, ensure that `kind get clusters` is pointing to the
+default kind cluster.
+
+## Deploy the Controller Manager
+
+The controller manager can be started via the following command
+
+```shell
+make kind-deploy
+```
+## validate
+
+Make sure you have all the below pods running
+
+```shell
+$ kubectl get po -n ironcore-system
+NAME                                           READY   STATUS    RESTARTS       AGE
+ironcore-apiserver-85995846f9-47247            1/1     Running   0              136m
+ironcore-controller-manager-84bf4cc6d5-l224c   2/2     Running   0              136m
+ironcore-etcd-0                                1/1     Running   0              143m
+```
+
+## Apply Sample Manifests
+
+The `config/samples` folder contains samples for all APIs supported by this project. You can apply any of the samples by
+running
+
+```shell
+kubectl apply -f config/samples/SOME_RESOURCE.yaml
+```
+
+## Cleanup
+
+To remove the APIs from your cluster, simply run
+
+```shell
+make uninstall
+```

--- a/docs/usage/storage/bucket.md
+++ b/docs/usage/storage/bucket.md
@@ -1,8 +1,9 @@
 # Bucket
-A `bucket` in `ironcore` refers to a storage resource that organizes and manages data, similar to the concept of buckets in cloud storage services like Amazon S3. Buckets serve as containers for storing objects, such as files or data blobs, and is crucial for managing storage workloads.
+A `Bucket` in `Ironcore` refers to a storage resource that organizes and manages data, similar to the concept of buckets in cloud storage services like Amazon S3. Buckets are containers for storing objects, such as files or data blobs, and are crucial for managing storage workloads.
 
 # Example Bucket Resource
-An example of how to define a `bucket` resource in `ironcore`
+An example of how to define a `Bucket` resource in `Ironcore`
+
 ```
 apiVersion: storage.ironcore.dev/v1alpha1
 kind: Bucket
@@ -11,35 +12,35 @@ metadata:
 spec:
   bucketClassRef:
     name: bucketclass-sample
-  # bucketPoolRef:
-  #   name: bucketpool-sample
+#  bucketPoolRef:
+#    name: bucketpool-sample
 ```
 
 # Key Fields:
 - `bucketClassRef`(`string`): 
-    - Mandatory field
-    - `BucketClassRef` is the BucketClass of a bucket
+  - Mandatory field
+  - `BucketClassRef` is the BucketClass of a bucket
 
 - `bucketPoolRef`(`string`):
-    - Optional field
-    -  `bucketPoolRef` indicates which BucketPool to use for the bucket, if not specified the controller itself picks the available bucketPool
+  - Optional field
+  -  `bucketPoolRef` indicates which BucketPool to use for the bucket, if not specified the controller itself picks the available bucketPool
 
 
 # Usage
-- **Data Storage**: Use buckets to store and organize data blobs, files, or any object-based data.
+- **Data Storage**: Use `Buckets` to store and organize data blobs, files, or any object-based data.
 
 - **Multi-Tenant Workloads**: Leverage buckets for isolated and secure data storage in multi-tenant environments by using separate BucketClass or BucketPool references.
 
-- **Secure Access**: Buckets store access credentials securely in their status. Applications can retrieve access details via Kubernetes secrets.
+- **Secure Access**: Buckets store a reference to the `Secret` securely in their status, and the `Secret` has the access credentials, which applications can retrieve access details from the `Secret`.
 
 # Reconciliation Process:
 - The controller detects changes and fetches bucket details.
 
 - Creation/Update ensures the backend bucket exists, metadata is synced, and credentials are updated.
 
-- The bucket will automatically sync with the backend storage system, Updates Bucket's state (e.g., `Available`, `Pending`, or `Error`) in the bucket's status.
+- The bucket will automatically sync with the backend storage system, and update the Bucket's state (e.g., `Available`, `Pending`, or `Error`) in the bucket's status.
 
-- Access details and credentials will be managed securely and updated in the bucket status.
+- Access details and credentials will be managed securely using Kubernetes `Secret` and the bucket status will track a reference to the `Secret`.
 
 - During deletion, resources will be cleaned up gracefully without manual intervention.
 

--- a/docs/usage/storage/bucket.md
+++ b/docs/usage/storage/bucket.md
@@ -1,1 +1,46 @@
 # Bucket
+A `bucket` in `ironcore` refers to a storage resource that organizes and manages data, similar to the concept of buckets in cloud storage services like Amazon S3. Buckets serve as containers for storing objects, such as files or data blobs, and is crucial for managing storage workloads.
+
+# Example Bucket Resource
+An example of how to define a `bucket` resource in `ironcore`
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: Bucket
+metadata:
+  name: bucket-sample
+spec:
+  bucketClassRef:
+    name: bucketclass-sample
+  # bucketPoolRef:
+  #   name: bucketpool-sample
+```
+
+# Key Fields:
+- `bucketClassRef`(`string`): 
+    - Mandatory field
+    - `BucketClassRef` is the BucketClass of a bucket
+
+- `bucketPoolRef`(`string`):
+    - Optional field
+    -  `bucketPoolRef` indicates which BucketPool to use for the bucket, if not specified the controller itself picks the available bucketPool
+
+
+# Usage
+- **Data Storage**: Use buckets to store and organize data blobs, files, or any object-based data.
+
+- **Multi-Tenant Workloads**: Leverage buckets for isolated and secure data storage in multi-tenant environments by using separate BucketClass or BucketPool references.
+
+- **Secure Access**: Buckets store access credentials securely in their status. Applications can retrieve access details via Kubernetes secrets.
+
+# Reconciliation Process:
+- The controller detects changes and fetches bucket details.
+
+- Creation/Update ensures the backend bucket exists, metadata is synced, and credentials are updated.
+
+- The bucket will automatically sync with the backend storage system, Updates Bucket's state (e.g., `Available`, `Pending`, or `Error`) in the bucket's status.
+
+- Access details and credentials will be managed securely and updated in the bucket status.
+
+- During deletion, resources will be cleaned up gracefully without manual intervention.
+
+- If the bucket is not ready (e.g., backend issues), reconciliation will retry

--- a/docs/usage/storage/bucketclass.md
+++ b/docs/usage/storage/bucketclass.md
@@ -1,1 +1,38 @@
 # BucketClass
+A BucketClass is a concept used to define and manage different types of storage buckets, typically based on resource capabilities
+
+# Example BucketClass Resource
+An example of how to define a bucketClass resource
+
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: BucketClass
+metadata:
+  name: bucketclass-sample
+capabilities:
+  tps: 100Mi
+  iops: 100
+```
+
+# Key Fields:
+- capabilities: Capabilities has `tps` and `iops` fields which need to specified, it's a mandatory field,
+  - tps(`string`): The `tps` represents trasactions per second
+
+  - iops(`string`):  `iops` is the number of input/output operations a storage device can complete per second.
+
+# Usage
+- **BucketClass Definition**: Create a BucketClass to set storage properties based on resource capibilities
+- **Associate with buckets**: Link a BucketClass to a Bucket using a reference in the Bucket resource.
+- **Dynamic configuration**: Update the BucketClass to modify storage properties for all its Buckets.
+
+# Reconciliation Process:
+
+- **Fetches & Validates**: Retrieves the BucketClass from the cluster and checks if it exists.
+
+- **Synchronizes State**: Keeps the BucketClass resource updated with its current state and dependencies.
+
+- **Monitors Dependencies**: Watches for changes in dependent Bucket resources and reacts accordingly.
+
+- **Handles Errors**: Requeues the reconciliation to handle errors and ensure successful completion.
+
+- **Handles Deletion**: Cleans up references, removes the finalizer, and ensures no dependent Buckets exist before deletion.

--- a/docs/usage/storage/bucketclass.md
+++ b/docs/usage/storage/bucketclass.md
@@ -1,8 +1,8 @@
 # BucketClass
-A BucketClass is a concept used to define and manage different types of storage buckets, typically based on resource capabilities
+A `BucketClass` is a concept used to define and manage different types of storage buckets, typically based on resource capabilities. It is conceptually similar to Kubernetes `StorageClass`, enabling users to specify the desired properties for an Ironcore `Bucket` resource creation.
 
 # Example BucketClass Resource
-An example of how to define a bucketClass resource
+An example of how to define a `BucketClass` resource in `Ironcore`
 
 ```
 apiVersion: storage.ironcore.dev/v1alpha1
@@ -15,21 +15,25 @@ capabilities:
 ```
 
 # Key Fields:
-- capabilities: Capabilities has `tps` and `iops` fields which need to specified, it's a mandatory field,
-  - tps(`string`): The `tps` represents trasactions per second
 
-  - iops(`string`):  `iops` is the number of input/output operations a storage device can complete per second.
+- `capabilities`: Capabilities has `tps` and `iops` fields which need to be specified, it's a mandatory field,
+  - `tps`(`string`): The `tps` represents transactions per second.
+
+  - `iops`(`string`):  `iops` is the number of input/output operations a storage device can complete per second.
 
 # Usage
-- **BucketClass Definition**: Create a BucketClass to set storage properties based on resource capibilities
-- **Associate with buckets**: Link a BucketClass to a Bucket using a reference in the Bucket resource.
-- **Dynamic configuration**: Update the BucketClass to modify storage properties for all its Buckets.
+
+- **BucketClass Definition**: Create a `BucketClass` to set storage properties based on resource capabilities.
+
+- **Associate with buckets**: Link a `BucketClass` to a `Bucket` using a reference in the Bucket resource.
+
+- **Dynamic configuration**: Update the `BucketClass` to modify storage properties for all its Buckets.
 
 # Reconciliation Process:
 
-- **Fetches & Validates**: Retrieves the BucketClass from the cluster and checks if it exists.
+- **Fetches & Validates**: Retrieves the `BucketClass` from the cluster and checks if it exists.
 
-- **Synchronizes State**: Keeps the BucketClass resource updated with its current state and dependencies.
+- **Synchronizes State**: Keeps the `BucketClass` resource updated with its current state and dependencies.
 
 - **Monitors Dependencies**: Watches for changes in dependent Bucket resources and reacts accordingly.
 

--- a/docs/usage/storage/bucketpool.md
+++ b/docs/usage/storage/bucketpool.md
@@ -1,7 +1,8 @@
 # BucketPool
-A `BucketPool` is a resource in `IronCore` that represents a pool of storage buckets managed collectively. It defines the infrastructure's storage configuration used to provision and manage buckets, ensuring resource availability and compatibility with associated `BucketClasses`.
+A `BucketPool` is a resource in `Ironcore` that represents a pool of storage buckets managed collectively. It defines the infrastructure's storage configuration used to provision and manage buckets, ensuring resource availability and compatibility with associated BucketClasses.
 
 # Example BucketPool Resource
+An example of how to define a `BucketPool` resource in `Ironcore`
 
 ```
 apiVersion: storage.ironcore.dev/v1alpha1

--- a/docs/usage/storage/bucketpool.md
+++ b/docs/usage/storage/bucketpool.md
@@ -1,1 +1,33 @@
 # BucketPool
+A `BucketPool` is a resource in `IronCore` that represents a pool of storage buckets managed collectively. It defines the infrastructure's storage configuration used to provision and manage buckets, ensuring resource availability and compatibility with associated `BucketClasses`.
+
+# Example BucketPool Resource
+
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: BucketPool
+metadata:
+  name: bucketpool-sample
+spec:
+  providerID: ironcore://shared
+#status:
+#  state: Available
+#  availableBucketClasses:
+#    ironcore.dev/fast-class: 10Gi
+#    ironcore.dev/slow-class: 100Gi
+```
+
+# Key Fields:
+- `ProviderID`(`string`):  The `providerId` helps the controller identify and communicate with the correct storage system within the specific backened storage porvider.
+
+    for example `ironcore://shared`
+
+# Reconciliation Process:
+
+- **Bucket Type Discovery**: It constantly checks what kinds of buckets (BucketClasses) are available in the `Ironcore` Infrastructure.
+
+- **Compatibility Check**: Evaluating whether the BucketPool can create and manage each bucket type based on its capabilities.
+
+- **Status Update**: Updating the BucketPool's status to indicate the bucket types it supports, like a menu of available options.
+
+- **Event Handling**: Watches for changes in BucketClass resources and ensures the associated BucketPool is reconciled when relevant changes occur.

--- a/docs/usage/storage/volume.md
+++ b/docs/usage/storage/volume.md
@@ -1,9 +1,9 @@
 # Volume
-The `IronCore` `Volume` is a storage abstraction provided by the `IronCore Runtime Interface` `(IRI)` service, designed to integrate with external storage backend for managing persistent storage. It acts as a managed storage unit, ensuring consistency, scalability, and compatibility with Kubernetes workloads.
-By integrating IronCore Volumes with Kubernetes, users benefit from seamless storage management, automation, and advanced features such as encryption and scalability, making it suitable for modern cloud-native and hybrid applications.
+The `Ironcore` `Volume` is a storage abstraction provided by the `Ironcore Runtime Interface` `(IRI)` service, designed to integrate with external storage backend for managing persistent storage. It acts as a managed storage unit, ensuring consistency, scalability, and compatibility with Kubernetes workloads.
+By integrating Ironcore Volumes with Kubernetes, users benefit from seamless storage management, automation, and advanced features such as encryption and scalability, making it suitable for modern cloud-native and hybrid applications.
 
 # Example Volume Resource
-An example of how to define a `volume` resource in `ironcore`
+An example of how to define a `Volume` resource in `Ironcore`
 
 ```
 apiVersion: storage.ironcore.dev/v1alpha1
@@ -21,11 +21,11 @@ spec:
 
 # Key Fields:
 
-- `volumeClassRef`(`string`): `volumeClassRef` refers to the name of an ironcore `volumeclass`( for eg: `slow`, `fast`, `super-fast` etc.) to create a volume,
+- `volumeClassRef`(`string`): `volumeClassRef` refers to the name of an Ironcore `volumeClass`( for eg: `slow`, `fast`, `super-fast` etc.) to create a volume,
 
 - `volumePoolRef` (`string`): 	`VolumePoolRef` indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable `VolumePoolRef`.
 
-- `resources`: Resources is a description of the volume's resources and capacity.
+- `resources`: `Resources` is a description of the volume's resources and capacity.
 
 # Reconciliation Process:
 
@@ -36,7 +36,7 @@ spec:
 - **Check IRI Volumes**: List and identify `IRI` volumes linked to the `Volume` resource.
 
 - **Create or Update Volume**:
-  - Create a new IRI volume if none exist.
+  - Create a new IRI volume if none exists.
   - Update existing IRI volumes if attributes like size or encryption need adjustments.
 
 - **Sync Status**: Reflect the IRI volume's state (e.g., Pending, Available) in the Kubernetes Volume resource's status.

--- a/docs/usage/storage/volume.md
+++ b/docs/usage/storage/volume.md
@@ -1,1 +1,44 @@
 # Volume
+The `IronCore` `Volume` is a storage abstraction provided by the `IronCore Runtime Interface` `(IRI)` service, designed to integrate with external storage backend for managing persistent storage. It acts as a managed storage unit, ensuring consistency, scalability, and compatibility with Kubernetes workloads.
+By integrating IronCore Volumes with Kubernetes, users benefit from seamless storage management, automation, and advanced features such as encryption and scalability, making it suitable for modern cloud-native and hybrid applications.
+
+# Example Volume Resource
+An example of how to define a `volume` resource in `ironcore`
+
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: Volume
+metadata:
+  name: volume-sample
+spec:
+  volumeClassRef:
+    name: volumeclass-sample
+  # volumePoolRef:
+  #   name: volumepool-sample
+  resources:
+    storage: 100Gi
+```
+
+# Key Fields:
+
+- `volumeClassRef`(`string`): `volumeClassRef` refers to the name of an ironcore `volumeclass`( for eg: `slow`, `fast`, `super-fast` etc.) to create a volume,
+
+- `volumePoolRef` (`string`): 	`VolumePoolRef` indicates which VolumePool to use for a volume. If unset, the scheduler will figure out a suitable `VolumePoolRef`.
+
+- `resources`: Resources is a description of the volume's resources and capacity.
+
+# Reconciliation Process:
+
+- **Fetch Volume Resource**: Retrieve the `Volume` resource and clean up any orphaned `IRI` volumes if the resource is missing.
+
+- **Add Finalizer**: Ensure a finalizer is added to manage cleanup during deletion.
+
+- **Check IRI Volumes**: List and identify `IRI` volumes linked to the `Volume` resource.
+
+- **Create or Update Volume**:
+  - Create a new IRI volume if none exist.
+  - Update existing IRI volumes if attributes like size or encryption need adjustments.
+
+- **Sync Status**: Reflect the IRI volume's state (e.g., Pending, Available) in the Kubernetes Volume resource's status.
+
+- **Handle Deletion**: Safely delete all associated IRI volumes and remove the finalizer to complete the resource lifecycle.

--- a/docs/usage/storage/volumeclass.md
+++ b/docs/usage/storage/volumeclass.md
@@ -1,8 +1,8 @@
 # VolumeClass
-The `VolumeClass` in `IronCore` is a Kubernetes-like abstraction that defines a set of parameters or configurations for provisioning storage resources through the `IronCore Runtime Interface (IRI)`. It is conceptually similar to Kubernetes `StorageClass`, enabling users to specify the desired properties for an IronCore `Volume` resource creation.
+The `VolumeClass` in `Ironcore` is a Kubernetes-like abstraction that defines a set of parameters or configurations for provisioning storage resources through the `Ironcore Runtime Interface (IRI)`. It is conceptually similar to Kubernetes `StorageClass`, enabling users to specify the desired properties for an Ironcore `Volume` resource creation.
 
 # Example VolumeClass Resource
-An example of how to define a volumeClass resource
+An example of how to define a `VolumeClass` resource in `Ironcore`
 
 ```
 apiVersion: storage.ironcore.dev/v1alpha1
@@ -15,15 +15,18 @@ capabilities:
 ```
 
 # Key Fields:
-- capabilities: Capabilities has tps and iops fields which need to specified, it's a mandatory field,
-  - tps(`string`): The `tps` represents trasactions per second
+- `capabilities`: Capabilities has tps and iops fields that need to be specified, it's a mandatory field,
+  - `tps`(`string`): The `tps` represents transactions per second.
 
-  - iops(`string`):  `iops` is the number of input/output operations a storage device can complete per second.
+  - `iops`(`string`): `iops` is the number of input/output operations a storage device can complete per second.
 
 # Usage
-- **VolumeClass Definition**: Create a volumeClass to set storage properties based on resource capibilities
-- **Associate with Volume**: Link a volumeClass to a Volume using a reference in the Volume resource.
-- **Dynamic configuration**: Update the volumeClass to modify storage properties for all its Volumes.
+
+- **VolumeClass Definition**: Create a `VolumeClass` to set storage properties based on resource capabilities.
+
+- **Associate with Volume**: Link a `VolumeClass` to a `Volume` using a reference in the Volume resource.
+
+- **Dynamic configuration**: Update the `VolumeClass` to modify storage properties for all its Volumes.
 
 # Reconciliation Process:
 

--- a/docs/usage/storage/volumeclass.md
+++ b/docs/usage/storage/volumeclass.md
@@ -1,1 +1,38 @@
 # VolumeClass
+The `VolumeClass` in `IronCore` is a Kubernetes-like abstraction that defines a set of parameters or configurations for provisioning storage resources through the `IronCore Runtime Interface (IRI)`. It is conceptually similar to Kubernetes `StorageClass`, enabling users to specify the desired properties for an IronCore `Volume` resource creation.
+
+# Example VolumeClass Resource
+An example of how to define a volumeClass resource
+
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: VolumeClass
+metadata:
+  name: volumeclass-sample
+capabilities:
+  tps: 100Mi
+  iops: 100
+```
+
+# Key Fields:
+- capabilities: Capabilities has tps and iops fields which need to specified, it's a mandatory field,
+  - tps(`string`): The `tps` represents trasactions per second
+
+  - iops(`string`):  `iops` is the number of input/output operations a storage device can complete per second.
+
+# Usage
+- **VolumeClass Definition**: Create a volumeClass to set storage properties based on resource capibilities
+- **Associate with Volume**: Link a volumeClass to a Volume using a reference in the Volume resource.
+- **Dynamic configuration**: Update the volumeClass to modify storage properties for all its Volumes.
+
+# Reconciliation Process:
+
+- **Fetches & Validates**: Retrieves the VolumeClass from the cluster and checks if it exists.
+
+- **Synchronizes State**: Keeps the VolumeClass resource updated with its current state and dependencies.
+
+- **Monitors Dependencies**: Watches for changes in dependent Volume resources and reacts accordingly.
+
+- **Handles Errors**: Requeues the reconciliation to handle errors and ensure successful completion.
+
+- **Handles Deletion**: Cleans up references, removes the finalizer, and ensures no dependent Volumes exist before deletion.

--- a/docs/usage/storage/volumepool.md
+++ b/docs/usage/storage/volumepool.md
@@ -1,1 +1,33 @@
 # VolumePool
+A `VolumePool` is a resource in `IronCore` that represents a pool of storage volume managed collectively. It defines the infrastructure's storage configuration used to provision and manage volumes, ensuring resource availability and compatibility with associated `VolumeClasses`.
+
+# Example Volume Resource
+
+```
+apiVersion: storage.ironcore.dev/v1alpha1
+kind: VolumePool
+metadata:
+  name: volumepool-sample
+spec:
+  providerID: ironcore://shared
+#status:
+#  state: Available
+#  availableVolumeClasses:
+#    ironcore.dev/fast-class: 10Gi
+#    ironcore.dev/slow-class: 100Gi
+```
+
+# Key Fields:
+- `ProviderID`(`string`):  The `providerId` helps the controller identify and communicate with the correct  storage system within the specific backened storage porvider.
+
+    for example `ironcore://shared`
+
+# Reconciliation Process:
+
+- **Volume Type Discovery**: It constantly checks what kinds of volumes (volumeClasses) are available in the `Ironcore` Infrastructure.
+
+- **Compatibility Check**: Evaluating whether the volumePool can create and manage each volume type based on its capabilities.
+
+- **Status Update**: Updating the VolumePool's status to indicate the volume types it supports, like a menu of available options.
+
+- **Event Handling**: Watches for changes in VolumeClass resources and ensures the associated VolumePool is reconciled when relevant changes occur.

--- a/docs/usage/storage/volumepool.md
+++ b/docs/usage/storage/volumepool.md
@@ -1,7 +1,8 @@
 # VolumePool
-A `VolumePool` is a resource in `IronCore` that represents a pool of storage volume managed collectively. It defines the infrastructure's storage configuration used to provision and manage volumes, ensuring resource availability and compatibility with associated `VolumeClasses`.
+A `VolumePool` is a resource in `Ironcore` that represents a pool of storage volume managed collectively. It defines the infrastructure's storage configuration used to provision and manage volumes, ensuring resource availability and compatibility with associated `VolumeClasses`.
 
-# Example Volume Resource
+# Example VolumePool Resource
+An example of how to define a `VolumePool` resource in `Ironcore`
 
 ```
 apiVersion: storage.ironcore.dev/v1alpha1
@@ -18,7 +19,7 @@ spec:
 ```
 
 # Key Fields:
-- `ProviderID`(`string`):  The `providerId` helps the controller identify and communicate with the correct  storage system within the specific backened storage porvider.
+- `providerID`(`string`): The `providerId` helps the controller identify and communicate with the correct storage system within the specific backened storage porvider.
 
     for example `ironcore://shared`
 

--- a/gen/swagger.json
+++ b/gen/swagger.json
@@ -2,7 +2,7 @@
 	"swagger": "2.0",
 	"info": {
 		"title": "Kubernetes",
-		"version": "v1.30.3"
+		"version": "1.31"
 	},
 	"paths": {
 		"/.well-known/openid-configuration/": {
@@ -65866,43 +65866,6 @@
 				}
 			]
 		},
-		"/logs/": {
-			"get": {
-				"schemes": [
-					"https"
-				],
-				"tags": [
-					"logs"
-				],
-				"operationId": "logFileListHandler",
-				"responses": {
-					"401": {
-						"description": "Unauthorized"
-					}
-				}
-			}
-		},
-		"/logs/{logpath}": {
-			"get": {
-				"schemes": [
-					"https"
-				],
-				"tags": [
-					"logs"
-				],
-				"operationId": "logFileHandler",
-				"responses": {
-					"401": {
-						"description": "Unauthorized"
-					}
-				}
-			},
-			"parameters": [
-				{
-					"$ref": "#/parameters/logpath-Noq7euwC"
-				}
-			]
-		},
 		"/openid/v1/jwks/": {
 			"get": {
 				"description": "get service account issuer OpenID JSON Web Key Set (contains public token verification keys)",
@@ -69569,6 +69532,9 @@
 		"io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBindingList": {
 			"description": "ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.",
 			"type": "object",
+			"required": [
+				"items"
+			],
 			"properties": {
 				"apiVersion": {
 					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -69632,6 +69598,9 @@
 		"io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyList": {
 			"description": "ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.",
 			"type": "object",
+			"required": [
+				"items"
+			],
 			"properties": {
 				"apiVersion": {
 					"description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -70839,11 +70808,11 @@
 					"format": "int32"
 				},
 				"ordinals": {
-					"description": "ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a \"0\" index to the first replica and increments the index by one for each additional replica requested. Using the ordinals field requires the StatefulSetStartOrdinal feature gate to be enabled, which is beta.",
+					"description": "ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a \"0\" index to the first replica and increments the index by one for each additional replica requested.",
 					"$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetOrdinals"
 				},
 				"persistentVolumeClaimRetentionPolicy": {
-					"description": "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.  +optional",
+					"description": "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is beta.",
 					"$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy"
 				},
 				"podManagementPolicy": {
@@ -71226,6 +71195,42 @@
 				}
 			}
 		},
+		"io.k8s.api.authorization.v1.FieldSelectorAttributes": {
+			"description": "FieldSelectorAttributes indicates a field limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
+			"type": "object",
+			"properties": {
+				"rawSelector": {
+					"description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
+					"type": "string"
+				},
+				"requirements": {
+					"description": "requirements is the parsed interpretation of a field selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement"
+					},
+					"x-kubernetes-list-type": "atomic"
+				}
+			}
+		},
+		"io.k8s.api.authorization.v1.LabelSelectorAttributes": {
+			"description": "LabelSelectorAttributes indicates a label limited access. Webhook authors are encouraged to * ensure rawSelector and requirements are not both set * consider the requirements field if set * not try to parse or consider the rawSelector field if set. This is to avoid another CVE-2022-2880 (i.e. getting different systems to agree on how exactly to parse a query is not something we want), see https://www.oxeye.io/resources/golang-parameter-smuggling-attack for more details. For the *SubjectAccessReview endpoints of the kube-apiserver: * If rawSelector is empty and requirements are empty, the request is not limited. * If rawSelector is present and requirements are empty, the rawSelector will be parsed and limited if the parsing succeeds. * If rawSelector is empty and requirements are present, the requirements should be honored * If rawSelector is present and requirements are present, the request is invalid.",
+			"type": "object",
+			"properties": {
+				"rawSelector": {
+					"description": "rawSelector is the serialization of a field selector that would be included in a query parameter. Webhook implementations are encouraged to ignore rawSelector. The kube-apiserver's *SubjectAccessReview will parse the rawSelector as long as the requirements are not present.",
+					"type": "string"
+				},
+				"requirements": {
+					"description": "requirements is the parsed interpretation of a label selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+					},
+					"x-kubernetes-list-type": "atomic"
+				}
+			}
+		},
 		"io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
 			"description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
 			"type": "object",
@@ -71305,9 +71310,17 @@
 			"description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
 			"type": "object",
 			"properties": {
+				"fieldSelector": {
+					"description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
+					"$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes"
+				},
 				"group": {
 					"description": "Group is the API Group of the Resource.  \"*\" means all.",
 					"type": "string"
+				},
+				"labelSelector": {
+					"description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default).",
+					"$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes"
 				},
 				"name": {
 					"description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
@@ -72697,7 +72710,7 @@
 					"format": "int32"
 				},
 				"managedBy": {
-					"description": "ManagedBy field indicates the controller that manages a Job. The k8s Job controller reconciles jobs which don't have this field at all or the field value is the reserved string `kubernetes.io/job-controller`, but skips reconciling Jobs with a custom value for this field. The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 64 characters.\n\nThis field is alpha-level. The job controller accepts setting the field when the feature gate JobManagedBy is enabled (disabled by default).",
+					"description": "ManagedBy field indicates the controller that manages a Job. The k8s Job controller reconciles jobs which don't have this field at all or the field value is the reserved string `kubernetes.io/job-controller`, but skips reconciling Jobs with a custom value for this field. The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first \"/\" must be a valid subdomain as defined by RFC 1123. All characters trailing the first \"/\" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 63 characters. This field is immutable.\n\nThis field is alpha-level. The job controller accepts setting the field when the feature gate JobManagedBy is enabled (disabled by default).",
 					"type": "string"
 				},
 				"manualSelector": {
@@ -72715,7 +72728,7 @@
 					"format": "int32"
 				},
 				"podFailurePolicy": {
-					"description": "Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.\n\nThis field is beta-level. It can be used when the `JobPodFailurePolicy` feature gate is enabled (enabled by default).",
+					"description": "Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.",
 					"$ref": "#/definitions/io.k8s.api.batch.v1.PodFailurePolicy"
 				},
 				"podReplacementPolicy": {
@@ -72731,7 +72744,7 @@
 					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
 				},
 				"successPolicy": {
-					"description": "successPolicy specifies the policy when the Job can be declared as succeeded. If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions. When the field is specified, it must be immutable and works only for the Indexed Jobs. Once the Job meets the SuccessPolicy, the lingering pods are terminated.\n\nThis field  is alpha-level. To use this field, you must enable the `JobSuccessPolicy` feature gate (disabled by default).",
+					"description": "successPolicy specifies the policy when the Job can be declared as succeeded. If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions. When the field is specified, it must be immutable and works only for the Indexed Jobs. Once the Job meets the SuccessPolicy, the lingering pods are terminated.\n\nThis field is beta-level. To use this field, you must enable the `JobSuccessPolicy` feature gate (enabled by default).",
 					"$ref": "#/definitions/io.k8s.api.batch.v1.SuccessPolicy"
 				},
 				"suspend": {
@@ -72786,7 +72799,7 @@
 					"type": "string"
 				},
 				"ready": {
-					"description": "The number of pods which have a Ready condition.",
+					"description": "The number of active pods which have a Ready condition and are not terminating (without a deletionTimestamp).",
 					"type": "integer",
 					"format": "int32"
 				},
@@ -73258,11 +73271,11 @@
 					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime"
 				},
 				"holderIdentity": {
-					"description": "holderIdentity contains the identity of the holder of a current lease.",
+					"description": "holderIdentity contains the identity of the holder of a current lease. If Coordinated Leader Election is used, the holder identity must be equal to the elected LeaseCandidate.metadata.name field.",
 					"type": "string"
 				},
 				"leaseDurationSeconds": {
-					"description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.",
+					"description": "leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measured against the time of last observed renewTime.",
 					"type": "integer",
 					"format": "int32"
 				},
@@ -73271,9 +73284,17 @@
 					"type": "integer",
 					"format": "int32"
 				},
+				"preferredHolder": {
+					"description": "PreferredHolder signals to a lease holder that the lease has a more optimal holder and should be given up. This field can only be set if Strategy is also set.",
+					"type": "string"
+				},
 				"renewTime": {
 					"description": "renewTime is a time when the current holder of a lease has last updated the lease.",
 					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime"
+				},
+				"strategy": {
+					"description": "Strategy indicates the strategy for picking the leader for coordinated leader election. If the field is not specified, there is no active coordination for this lease. (Alpha) Using this field requires the CoordinatedLeaderElection feature gate to be enabled.",
+					"type": "string"
 				}
 			}
 		},
@@ -73720,20 +73741,6 @@
 				},
 				"volumeID": {
 					"description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-					"type": "string"
-				}
-			}
-		},
-		"io.k8s.api.core.v1.ClaimSource": {
-			"description": "ClaimSource describes a reference to a ResourceClaim.\n\nExactly one of these fields should be set.  Consumers of this type must treat an empty object as if it has an unknown value.",
-			"type": "object",
-			"properties": {
-				"resourceClaimName": {
-					"description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.",
-					"type": "string"
-				},
-				"resourceClaimTemplateName": {
-					"description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.",
 					"type": "string"
 				}
 			}
@@ -74411,6 +74418,19 @@
 						"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
 					}
 				},
+				"allocatedResourcesStatus": {
+					"description": "AllocatedResourcesStatus represents the status of various resources allocated for this Pod.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.ResourceStatus"
+					},
+					"x-kubernetes-list-map-keys": [
+						"name"
+					],
+					"x-kubernetes-list-type": "map",
+					"x-kubernetes-patch-merge-key": "name",
+					"x-kubernetes-patch-strategy": "merge"
+				},
 				"containerID": {
 					"description": "ContainerID is the ID of the container in the format '<type>://<container_id>'. Where type is a container runtime identifier, returned from Version call of CRI API (for example \"containerd\").",
 					"type": "string"
@@ -74452,6 +74472,10 @@
 					"description": "State holds details about the container's current condition.",
 					"$ref": "#/definitions/io.k8s.api.core.v1.ContainerState"
 				},
+				"user": {
+					"description": "User represents user identity information initially attached to the first process of the container",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ContainerUser"
+				},
 				"volumeMounts": {
 					"description": "Status of volume mounts.",
 					"type": "array",
@@ -74464,6 +74488,16 @@
 					"x-kubernetes-list-type": "map",
 					"x-kubernetes-patch-merge-key": "mountPath",
 					"x-kubernetes-patch-strategy": "merge"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ContainerUser": {
+			"description": "ContainerUser represents user identity information",
+			"type": "object",
+			"properties": {
+				"linux": {
+					"description": "Linux holds user identity information initially attached to the first process of the containers in Linux. Note that the actual running identity can be changed if the process has enough privilege to do so.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.LinuxContainerUser"
 				}
 			}
 		},
@@ -75420,6 +75454,9 @@
 		"io.k8s.api.core.v1.HostIP": {
 			"description": "HostIP represents a single IP address allocated to the host.",
 			"type": "object",
+			"required": [
+				"ip"
+			],
 			"properties": {
 				"ip": {
 					"description": "IP is the IP address assigned to the host",
@@ -75570,6 +75607,25 @@
 				},
 				"targetPortal": {
 					"description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+					"type": "string"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ImageVolumeSource": {
+			"description": "ImageVolumeSource represents a image volume resource.",
+			"type": "object",
+			"properties": {
+				"pullPolicy": {
+					"description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+					"type": "string",
+					"enum": [
+						"Always",
+						"IfNotPresent",
+						"Never"
+					]
+				},
+				"reference": {
+					"description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
 					"type": "string"
 				}
 			}
@@ -75759,6 +75815,35 @@
 						"$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
 					},
 					"x-kubernetes-list-type": "atomic"
+				}
+			}
+		},
+		"io.k8s.api.core.v1.LinuxContainerUser": {
+			"description": "LinuxContainerUser represents user identity information in Linux containers",
+			"type": "object",
+			"required": [
+				"uid",
+				"gid"
+			],
+			"properties": {
+				"gid": {
+					"description": "GID is the primary gid initially attached to the first process in the container",
+					"type": "integer",
+					"format": "int64"
+				},
+				"supplementalGroups": {
+					"description": "SupplementalGroups are the supplemental groups initially attached to the first process in the container",
+					"type": "array",
+					"items": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"x-kubernetes-list-type": "atomic"
+				},
+				"uid": {
+					"description": "UID is the primary uid initially attached to the first process in the container",
+					"type": "integer",
+					"format": "int64"
 				}
 			}
 		},
@@ -76155,6 +76240,16 @@
 				}
 			}
 		},
+		"io.k8s.api.core.v1.NodeFeatures": {
+			"description": "NodeFeatures describes the set of features implemented by the CRI implementation. The features contained in the NodeFeatures should depend only on the cri implementation independent of runtime handlers.",
+			"type": "object",
+			"properties": {
+				"supplementalGroupsPolicy": {
+					"description": "SupplementalGroupsPolicy is set to true if the runtime supports SupplementalGroupsPolicy and ContainerUser.",
+					"type": "boolean"
+				}
+			}
+		},
 		"io.k8s.api.core.v1.NodeList": {
 			"description": "NodeList is the whole list of all Nodes which have been registered with master.",
 			"type": "object",
@@ -76205,11 +76300,15 @@
 			}
 		},
 		"io.k8s.api.core.v1.NodeRuntimeHandlerFeatures": {
-			"description": "NodeRuntimeHandlerFeatures is a set of runtime features.",
+			"description": "NodeRuntimeHandlerFeatures is a set of features implemented by the runtime handler.",
 			"type": "object",
 			"properties": {
 				"recursiveReadOnlyMounts": {
 					"description": "RecursiveReadOnlyMounts is set to true if the runtime handler supports RecursiveReadOnlyMounts.",
+					"type": "boolean"
+				},
+				"userNamespaces": {
+					"description": "UserNamespaces is set to true if the runtime handler supports UserNamespaces, including for volumes.",
 					"type": "boolean"
 				}
 			}
@@ -76357,7 +76456,7 @@
 					}
 				},
 				"capacity": {
-					"description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
+					"description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/reference/node/node-status/#capacity",
 					"type": "object",
 					"additionalProperties": {
 						"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
@@ -76383,6 +76482,10 @@
 				"daemonEndpoints": {
 					"description": "Endpoints of daemons running on the Node.",
 					"$ref": "#/definitions/io.k8s.api.core.v1.NodeDaemonEndpoints"
+				},
+				"features": {
+					"description": "Features describes the set of features implemented by the CRI implementation.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.NodeFeatures"
 				},
 				"images": {
 					"description": "List of container images on this node",
@@ -76464,7 +76567,7 @@
 					"type": "string"
 				},
 				"kubeProxyVersion": {
-					"description": "KubeProxy Version reported by the node.",
+					"description": "Deprecated: KubeProxy Version reported by the node.",
 					"type": "string"
 				},
 				"kubeletVersion": {
@@ -76714,7 +76817,7 @@
 					"type": "string"
 				},
 				"volumeAttributesClassName": {
-					"description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+					"description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
 					"type": "string"
 				},
 				"volumeMode": {
@@ -76755,10 +76858,10 @@
 					"additionalProperties": {
 						"type": "string",
 						"enum": [
-							"ControllerResizeFailed",
 							"ControllerResizeInProgress",
-							"NodeResizeFailed",
+							"ControllerResizeInfeasible",
 							"NodeResizeInProgress",
+							"NodeResizeInfeasible",
 							"NodeResizePending"
 						]
 					},
@@ -76792,11 +76895,11 @@
 					"x-kubernetes-patch-strategy": "merge"
 				},
 				"currentVolumeAttributesClassName": {
-					"description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim This is an alpha field and requires enabling VolumeAttributesClass feature.",
+					"description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim This is a beta field and requires enabling VolumeAttributesClass feature (off by default).",
 					"type": "string"
 				},
 				"modifyVolumeStatus": {
-					"description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is an alpha field and requires enabling VolumeAttributesClass feature.",
+					"description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is a beta field and requires enabling VolumeAttributesClass feature (off by default).",
 					"$ref": "#/definitions/io.k8s.api.core.v1.ModifyVolumeStatus"
 				},
 				"phase": {
@@ -77019,7 +77122,7 @@
 					"$ref": "#/definitions/io.k8s.api.core.v1.StorageOSPersistentVolumeSource"
 				},
 				"volumeAttributesClassName": {
-					"description": "Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is an alpha field and requires enabling VolumeAttributesClass feature.",
+					"description": "Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is a beta field and requires enabling VolumeAttributesClass feature (off by default).",
 					"type": "string"
 				},
 				"volumeMode": {
@@ -77041,7 +77144,7 @@
 			"type": "object",
 			"properties": {
 				"lastPhaseTransitionTime": {
-					"description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).",
+					"description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions.",
 					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
 				},
 				"message": {
@@ -77149,7 +77252,7 @@
 					"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
 				},
 				"matchLabelKeys": {
-					"description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+					"description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
 					"type": "array",
 					"items": {
 						"type": "string"
@@ -77157,7 +77260,7 @@
 					"x-kubernetes-list-type": "atomic"
 				},
 				"mismatchLabelKeys": {
-					"description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+					"description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
 					"type": "array",
 					"items": {
 						"type": "string"
@@ -77284,6 +77387,9 @@
 		"io.k8s.api.core.v1.PodIP": {
 			"description": "PodIP represents a single IP address allocated to the pod.",
 			"type": "object",
+			"required": [
+				"ip"
+			],
 			"properties": {
 				"ip": {
 					"description": "IP is the IP address assigned to the pod",
@@ -77353,7 +77459,7 @@
 			}
 		},
 		"io.k8s.api.core.v1.PodResourceClaim": {
-			"description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+			"description": "PodResourceClaim references exactly one ResourceClaim, either directly or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim for the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
 			"type": "object",
 			"required": [
 				"name"
@@ -77363,9 +77469,13 @@
 					"description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
 					"type": "string"
 				},
-				"source": {
-					"description": "Source describes where to find the ResourceClaim.",
-					"$ref": "#/definitions/io.k8s.api.core.v1.ClaimSource"
+				"resourceClaimName": {
+					"description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+					"type": "string"
+				},
+				"resourceClaimTemplateName": {
+					"description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must be set.",
+					"type": "string"
 				}
 			}
 		},
@@ -77381,7 +77491,7 @@
 					"type": "string"
 				},
 				"resourceClaimName": {
-					"description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+					"description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
 					"type": "string"
 				}
 			}
@@ -77443,13 +77553,21 @@
 					"$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile"
 				},
 				"supplementalGroups": {
-					"description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.",
+					"description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.",
 					"type": "array",
 					"items": {
 						"type": "integer",
 						"format": "int64"
 					},
 					"x-kubernetes-list-type": "atomic"
+				},
+				"supplementalGroupsPolicy": {
+					"description": "Defines how supplemental groups of the first container processes are calculated. Valid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Merge\"` means that the container's provided SupplementalGroups and FsGroup (specified in SecurityContext) will be merged with the primary user's groups as defined in the container image (in /etc/group).\n - `\"Strict\"` means that the container's provided SupplementalGroups and FsGroup (specified in SecurityContext) will be used instead of any groups defined in the container image.",
+					"type": "string",
+					"enum": [
+						"Merge",
+						"Strict"
+					]
 				},
 				"sysctls": {
 					"description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
@@ -77589,7 +77707,7 @@
 					"x-kubernetes-patch-strategy": "merge"
 				},
 				"nodeName": {
-					"description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+					"description": "NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
 					"type": "string"
 				},
 				"nodeSelector": {
@@ -77601,7 +77719,7 @@
 					"x-kubernetes-map-type": "atomic"
 				},
 				"os": {
-					"description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
+					"description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
 					"$ref": "#/definitions/io.k8s.api.core.v1.PodOS"
 				},
 				"overhead": {
@@ -78079,7 +78197,7 @@
 					"format": "int32"
 				},
 				"sources": {
-					"description": "sources is the list of volume projections",
+					"description": "sources is the list of volume projections. Each entry in this list handles one source.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
@@ -78397,6 +78515,10 @@
 				"name": {
 					"description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
 					"type": "string"
+				},
+				"request": {
+					"description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
+					"type": "string"
 				}
 			}
 		},
@@ -78421,6 +78543,23 @@
 				}
 			},
 			"x-kubernetes-map-type": "atomic"
+		},
+		"io.k8s.api.core.v1.ResourceHealth": {
+			"description": "ResourceHealth represents the health of a resource. It has the latest device health information. This is a part of KEP https://kep.k8s.io/4680 and historical health changes are planned to be added in future iterations of a KEP.",
+			"type": "object",
+			"required": [
+				"resourceID"
+			],
+			"properties": {
+				"health": {
+					"description": "Health of the resource. can be one of:\n - Healthy: operates as normal\n - Unhealthy: reported unhealthy. We consider this a temporary health issue\n              since we do not have a mechanism today to distinguish\n              temporary and permanent issues.\n - Unknown: The status cannot be determined.\n            For example, Device Plugin got unregistered and hasn't been re-registered since.\n\nIn future we may want to introduce the PermanentlyUnhealthy Status.",
+					"type": "string"
+				},
+				"resourceID": {
+					"description": "ResourceID is the unique identifier of the resource. See the ResourceID type for more information.",
+					"type": "string"
+				}
+			}
 		},
 		"io.k8s.api.core.v1.ResourceQuota": {
 			"description": "ResourceQuota sets aggregate quota restrictions enforced per namespace",
@@ -78571,6 +78710,29 @@
 					"additionalProperties": {
 						"$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
 					}
+				}
+			}
+		},
+		"io.k8s.api.core.v1.ResourceStatus": {
+			"type": "object",
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"description": "Name of the resource. Must be unique within the pod and match one of the resources from the pod spec.",
+					"type": "string"
+				},
+				"resources": {
+					"description": "List of unique Resources health. Each element in the list contains an unique resource ID and resource health. At a minimum, ResourceID must uniquely identify the Resource allocated to the Pod on the Node for the lifetime of a Pod. See ResourceID type for it's definition.",
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/io.k8s.api.core.v1.ResourceHealth"
+					},
+					"x-kubernetes-list-map-keys": [
+						"resourceID"
+					],
+					"x-kubernetes-list-type": "map"
 				}
 			}
 		},
@@ -78987,7 +79149,7 @@
 					"type": "boolean"
 				},
 				"procMount": {
-					"description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Default\"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.\n - `\"Unmasked\"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.",
+					"description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Default\"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.\n - `\"Unmasked\"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.",
 					"type": "string",
 					"enum": [
 						"Default",
@@ -79808,6 +79970,10 @@
 					"description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
 					"$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource"
 				},
+				"image": {
+					"description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath). The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+					"$ref": "#/definitions/io.k8s.api.core.v1.ImageVolumeSource"
+				},
 				"iscsi": {
 					"description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
 					"$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource"
@@ -79960,7 +80126,7 @@
 			}
 		},
 		"io.k8s.api.core.v1.VolumeProjection": {
-			"description": "Projection that may be projected along with other supported volume types",
+			"description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
 			"type": "object",
 			"properties": {
 				"clusterTrustBundle": {
@@ -82200,7 +82366,8 @@
 					"type": "integer",
 					"format": "int32"
 				}
-			}
+			},
+			"x-kubernetes-map-type": "atomic"
 		},
 		"io.k8s.api.node.v1.Overhead": {
 			"description": "Overhead structure represents the resource overhead associated with running a pod.",
@@ -84154,7 +84321,7 @@
 					"type": "boolean"
 				},
 				"x-kubernetes-validations": {
-					"description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.",
+					"description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language.",
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
@@ -84748,6 +84915,11 @@
 				{
 					"group": "coordination.k8s.io",
 					"kind": "DeleteOptions",
+					"version": "v1alpha1"
+				},
+				{
+					"group": "coordination.k8s.io",
+					"kind": "DeleteOptions",
 					"version": "v1beta1"
 				},
 				{
@@ -84878,7 +85050,7 @@
 				{
 					"group": "resource.k8s.io",
 					"kind": "DeleteOptions",
-					"version": "v1alpha2"
+					"version": "v1alpha3"
 				},
 				{
 					"group": "scheduling.k8s.io",
@@ -84921,6 +85093,32 @@
 					"version": "v1alpha1"
 				}
 			]
+		},
+		"io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement": {
+			"description": "FieldSelectorRequirement is a selector that contains values, a key, and an operator that relates the key and values.",
+			"type": "object",
+			"required": [
+				"key",
+				"operator"
+			],
+			"properties": {
+				"key": {
+					"description": "key is the field selector key that the requirement applies to.",
+					"type": "string"
+				},
+				"operator": {
+					"description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. The list of operators may grow in the future.",
+					"type": "string"
+				},
+				"values": {
+					"description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"x-kubernetes-list-type": "atomic"
+				}
+			}
 		},
 		"io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
 			"description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
@@ -85263,11 +85461,6 @@
 					"group": "",
 					"kind": "Status",
 					"version": "v1"
-				},
-				{
-					"group": "resource.k8s.io",
-					"kind": "Status",
-					"version": "v1alpha2"
 				}
 			]
 		},
@@ -85494,6 +85687,11 @@
 				{
 					"group": "coordination.k8s.io",
 					"kind": "WatchEvent",
+					"version": "v1alpha1"
+				},
+				{
+					"group": "coordination.k8s.io",
+					"kind": "WatchEvent",
 					"version": "v1beta1"
 				},
 				{
@@ -85624,7 +85822,7 @@
 				{
 					"group": "resource.k8s.io",
 					"kind": "WatchEvent",
-					"version": "v1alpha2"
+					"version": "v1alpha3"
 				},
 				{
 					"group": "scheduling.k8s.io",
@@ -86033,14 +86231,6 @@
 			"description": "If set, the number of bytes to read from the server before terminating the log output. This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.",
 			"name": "limitBytes",
 			"in": "query"
-		},
-		"logpath-Noq7euwC": {
-			"uniqueItems": true,
-			"type": "string",
-			"description": "path to the log",
-			"name": "logpath",
-			"in": "path",
-			"required": true
 		},
 		"namespace-vgWSWtn3": {
 			"uniqueItems": true,


### PR DESCRIPTION
- Add the `ironcore` and its dependencies installation steps
- Add usage documents for `Bucket`, `BucketClass`, `BucketPool`, `Volume`, `VolumeClass` and `VolumePool` 
- Explained each field for every resource referred in the example yamls
- Described the reconciliation logic

Fixes #1192 