### PR TITLE
Add usage doc for `virtualIP`, `networkPolicy`, `networkInterface`, and `NATGateway`

### DIFF
--- a/docs/usage/networking/natgateway.md
+++ b/docs/usage/networking/natgateway.md
@@ -51,8 +51,8 @@ Imagine you have a private server in a private subnet without a public IP. It ne
 After reconciling all `NATGateways`, log the successful reconciliation and update the `NATGateways` status with the corresponding values for `ips`as shown below.
 
 ```
-#status:
-#  ips:
-#  - name: ip1
-#    ip: 10.0.0.1
+status:
+  ips:
+  - name: ip1
+    ip: 10.0.0.1
 ```

--- a/docs/usage/networking/natgateway.md
+++ b/docs/usage/networking/natgateway.md
@@ -1,1 +1,58 @@
 # NATGateway
+In the `Ironcore` project, a `NATGateway` (Network Address Translation Gateway) facilitates outbound internet connectivity in private subnets, ensuring that instances in private subnets can access external services without exposing them to unauthorized inbound traffic.
+
+It is a critical network service that provides secure and controlled internet access for private resources in the `Ironcore` infrastructure. It is enforced by the underlying `Ironcore's` network plugin called <a href="https://github.com/ironcore-dev/ironcore-net/blob/main/apinetlet/controllers/natgateway_controller.go"> ironcore-net </a>
+
+# Example NATGateway Resource
+An example of how to define a `NATGateway` resource in `Ironcore`
+
+```
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: NATGateway
+metadata:
+  namespace: default
+  name: natgateway-sample
+spec:
+  type: Public
+  ipFamily: IPv4
+  portsPerNetworkInterface: 64
+  networkRef:
+    name: network-sample
+```
+
+# Key Fields 
+- `type`(`string`): This represents a NATGateway type that allocates and routes a stable public IP. The supported value for type is `public`
+
+- `ipFamily`(`string`): `IPFamily` is the IP family of the `NATGateway`. Supported values for IPFamily are `IPv4` and `IPv6`.
+
+- `portsPerNetworkInterface`(`int32`): This Specifies the number of ports allocated per network interface and controls how many simultaneous connections can be handled per interface. 
+
+    If empty, 2048 (DefaultPortsPerNetworkInterface) is the default.
+
+- `networkRef`(`string`): It represents which network this `NATGateway` serves.
+
+# Example Use Case:
+Imagine you have a private server in a private subnet without a public IP. It needs to download software updates from the internet. Instead of giving it direct internet access (which compromises security), the server sends its requests through the NAT Gateway. The NAT Gateway fetches the updates and returns them to the server while keeping the server's private IP hidden from the external world.
+
+# Reconciliation Process:
+
+- **Fetch NATGateway Resource**: It fetches the current state of `NATGateways`, Based on user specifications the desired state of `NATGateway` is determined. This includes the number of NAT Gateways, their types, associated subnets, and routing configurations.
+
+- **Compare and Reconcile**: The reconciler keeps monitoring the state of NAT Gateways to detect any changes or drifts from the desired state, triggering the reconciliation process as needed.
+    - Creation: If a NAT Gateway specified in the desired state does not exist in the current state, it is created. For instance, creating a public NAT Gateway in a public subnet to provide internet access to instances in private subnets.
+
+    - Update: If a NAT Gateway exists but its configuration differs from the desired state, it is updated accordingly. This may involve modifying routing tables or changing associated Elastic IPs.
+
+    - Deletion: If a NAT Gateway exists in the current state but is not present in the desired state, it is deleted to prevent unnecessary resource utilization.
+
+- **Error Handling and Logging**: Throughout the reconciliation process, any errors encountered are logged, schedule retries as necessary to ensure eventual consistency.
+
+- **Update Status**:
+After reconciling all `NATGateways`, log the successful reconciliation and update the `NATGateways` status with the corresponding values for `ips`as shown below.
+
+```
+#status:
+#  ips:
+#  - name: ip1
+#    ip: 10.0.0.1
+```

--- a/docs/usage/networking/networkinterface.md
+++ b/docs/usage/networking/networkinterface.md
@@ -22,16 +22,16 @@ spec:
     virtualIPRef:
       name: virtualip-sample
 ```
-**Note**: For a detailed end-to-end example to understand the ephemeral and non `NetworkInterface`, please refer <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e">E2E Examples</a>
+**Note**: For a detailed end-to-end example to understand the ephemeral and non-ephemeral `NetworkInterface` resource, please refer <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e">E2E Examples</a>
 
 # Key Fields 
-- **networkRef**: `NetworkRef` is the Network this NetworkInterface is connected to
+- `networkRef`(`string`): `NetworkRef` is the Network this NetworkInterface is connected to
 
-- **ipFamilies**: `IPFamilies` defines the list of IPFamilies this `NetworkInterface` supports. For eg: `IPV4` and `IPV6`
+- `ipFamilies`(`list`): `IPFamilies` defines the list of IPFamilies this `NetworkInterface` supports. Supported values for IPFamily are `IPv4` and `IPv6`.
 
-- **ips**: `IPs` are the list of provided internal IPs which should be assigned to this NetworkInterface
+- `ips`(`list`): `IPs` are the list of provided internal IPs which should be assigned to this NetworkInterface
 
-- **virtualIP**: `VirtualIP` specifies the public ip that should be assigned to this NetworkInterface.
+- `virtualIP`: `VirtualIP` specifies the public ip that should be assigned to this NetworkInterface.
 
 # Reconciliation Process:
 
@@ -43,7 +43,7 @@ If the Machine is marked for deletion (indicated by a non-zero DeletionTimestamp
 Analyze the Machine's specification to identify the desired ephemeral NetworkInterface resources.
 Construct a map detailing these desired NetworkInterfaces, including their configurations and expected states.
 
-- **Fetch Existing Network Interfaces**:
+- **Fetch Existing NetworkInterfaces**:
 List all existing NetworkInterface resources within the same namespace as the Machine.
 
 - **Compare and Reconcile**:

--- a/docs/usage/networking/networkinterface.md
+++ b/docs/usage/networking/networkinterface.md
@@ -1,1 +1,76 @@
 # NetworkInterface
+A `NetworkInterface` resource in `Ironcore` represents a connection point between a virtual machine(VM) and a virtual network. It encapsulates the configuration and life cycle management of the virtual network interface, ensuring seamless connectivity for VMs.
+
+The `MachineEphemeralNetworkInterfaceReconciler` is responsible for managing the lifecycle of ephemeral network interfaces associated with machines. Its primary function is to ensure that the actual state of these network interfaces aligns with the desired state specified in each machine's configuration.
+
+# Example NetworkPolicy Resource
+An example of how to define a `NetworkInterface` resource in `Ironcore`
+
+```
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: NetworkInterface
+metadata:
+  name: networkinterface-sample
+spec:
+  networkRef:
+    name: network-sample
+  ipFamilies:
+    - IPv4
+  ips:
+    - value: 10.0.0.1 # internal IP
+  virtualIP:
+    virtualIPRef:
+      name: virtualip-sample
+```
+**Note**: For a detailed end-to-end example to understand the ephemeral and non `NetworkInterface`, please refer <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e">E2E Examples</a>
+
+# Key Fields 
+- **networkRef**: `NetworkRef` is the Network this NetworkInterface is connected to
+
+- **ipFamilies**: `IPFamilies` defines the list of IPFamilies this `NetworkInterface` supports. For eg: `IPV4` and `IPV6`
+
+- **ips**: `IPs` are the list of provided internal IPs which should be assigned to this NetworkInterface
+
+- **virtualIP**: `VirtualIP` specifies the public ip that should be assigned to this NetworkInterface.
+
+# Reconciliation Process:
+
+- **Fetch Machine Resource**:
+Retrieve the specified Machine resource from the reconciliation request.
+If the Machine is marked for deletion (indicated by a non-zero DeletionTimestamp), exit the process without further action.
+
+- **Generate Desired Ephemeral Network Interfaces**:
+Analyze the Machine's specification to identify the desired ephemeral NetworkInterface resources.
+Construct a map detailing these desired NetworkInterfaces, including their configurations and expected states.
+
+- **Fetch Existing Network Interfaces**:
+List all existing NetworkInterface resources within the same namespace as the Machine.
+
+- **Compare and Reconcile**:
+    - For each existing Network Interface:
+Determine if it is managed by the current Machine and whether it matches the desired state.
+    - If unmanaged but should be managed, avoid adopting it to prevent conflicts.
+    - For each desired Network Interface not present:
+Create the missing `NetworkInterface` and establish the Machine as its controller.
+
+- **Handle Errors**:
+Collect any errors encountered during the reconciliation of individual NetworkInterfaces.
+Log these errors and schedule retries as necessary to ensure eventual consistency.
+
+- **Update Status**:
+After reconciling all NetworkInterfaces, log the successful reconciliation and update the `NetworkInterface` status with the corresponding values for `ips`, `state`, and `virtualIP`, as shown below.
+
+```
+status:
+  ips:
+  - 10.0.0.1
+  lastStateTransitionTime: "2025-01-13T11:39:17Z"
+  state: Available
+  virtualIP: 172.89.244.23
+```
+The `state` is updated as one of the following lifecycle states based on the reconciliation result
+- **Pending**
+- **Available**
+- **Error**
+
+

--- a/docs/usage/networking/networkpolicy.md
+++ b/docs/usage/networking/networkpolicy.md
@@ -1,1 +1,87 @@
 # NetworkPolicy
+In `Ironcore`, NetworkPolicies are implemented based on the standard Kubernetes `NetworkPolicy` approach, which is enforced by the underlying `Ironcore's` network plugin <a href="https://github.com/ironcore-dev/ironcore-net/blob/main/apinetlet/controllers/networkpolicy_controller.go"> ironcore-net </a> and other components. These policies use label selectors to define the source and destination of allowed traffic within the same network and can specify rules for both ingress (incoming) and egress (outgoing) traffic. 
+
+In the `Ironcore` ecosystem, the `NetworkPolicy` has the following characteristics:
+
+- NetworkPolicy is applied exclusively to NetworkInterfaces selected using label selectors.
+
+- These NetworkInterfaces must belong to the same network.
+
+- The policy governs traffic to and from other `NetworkInterfaces`, `LoadBalancers`, etc., based on the rules defined in the NetworkPolicy.
+
+# Example NetworkPolicy Resource
+An example of how to define a `NetworkPolicy` resource in `Ironcore`
+
+```
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: NetworkPolicy
+metadata:
+  namespace: default
+  name: my-network-policy
+spec:
+  networkRef:
+    name: my-network
+  networkInterfaceSelector:
+    matchLabels:
+      app: db
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 172.17.0.0/16
+    - objectSelector:
+        kind: NetworkInterface
+        matchLabels:
+          app: web
+    - objectSelector:
+        kind: LoadBalancer
+        matchLabels:
+          app: web
+    # Ports always have to be specified. Only traffic matching the ports
+    # will be allowed.
+    ports:
+    - protocol: TCP
+      port: 5432
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 8080
+```
+https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/network-policy
+
+(`Note`: Refer to <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/network-policy">E2E Examples</a> for more detailed example on networkpolicy to understant e2e flow)
+
+# Key Fields
+
+- `networkRef`(`string`): NetworkRef is the Network to regulate using this NetworkPolicy.
+
+- `networkInterfaceSelector`(`labelSelector`): NetworkInterfaceSelector defines the target `NetworkInterfaces` for which this `NetworkPolicy` should be applied.
+
+- `policyTypes`(`list`): There are two supported policyTypes `Ingress` and `Egress`.
+
+- `ingress`(`list`): ingress defines the list of `NetworkPolicyIngressRules`. Each NetworkPolicy may include a list of allowed `ingress` rules. Each rule allows traffic that matches both the `from` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port, from one of three sources, the first specified via an ipBlock, the second and third via different objectSelector.
+
+- `egress`(`list`): egress defines the list of `NetworkPolicyEgressRules`. Each NetworkPolicy may include a list of allowed egress rules. Each rule allows traffic that matches both `to` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port to any destination in 10.0.0.0/24.
+
+# Reconciliation Process:
+The `NetworkPolicyReconciler` in the Ironcore project is responsible for managing the lifecycle of `NetworkPolicy` resources. Its primary function is to ensure that the rules specified by the user in the NetworkPolicy resource are enforced and applied on the target `NetworkInterface`.
+
+The <a href="https://github.com/ironcore-dev/ironcore-net/blob/main/apinetlet/controllers/networkpolicy_controller.go"> apinetlet </a> component in `ironcore-net` plugin is responsible for translating the policy rules into another APInet type resource `NetworkPolicyRule`. Finally, the <a href="https://github.com/ironcore-dev/ironcore-net/blob/main/metalnetlet/controllers/networkinterface_controller.go"> metalnetlet </a> component in `ironcore-net` and other components propagates these rules for enforcement at `dpservice` level in the Ironcore infrastucture.
+
+The reconciliation process involves several key steps:
+
+- **Fetching the NetworkPolicy Resource**: The reconciler retrieves the NetworkPolicy resource specified in the reconciliation request. If the resource is not found, it may have been deleted, and the reconciler will handle this scenario appropriately.
+
+- **Validating the NetworkPolicy**: The retrieved NetworkPolicy is validated to ensure it confirms the expected specifications. This includes checking fields such as NetworkRef, NetworkInterfaceSelector, Ingress, Egress, and PolicyTypes to ensure they are correctly defined.
+
+- **Fetching Associated Network Interfaces**: Using the NetworkInterfaceSelector, the reconciler identifies the network interfaces that are subject to the policy.
+
+- **Applying Policy Rules**: The reconciler translates the ingress and egress rules defined in the NetworkPolicy into configurations that can be enforced by the underlying network infrastructure. This involves interacting with other components responsible for NetworkPolicy or Firewall rule enforcement.
+
+- **Handling Errors and Reconciliation Loops**: If errors occur during any of the above steps, the reconciler will log the issues and may retry the reconciliation. 
+

--- a/docs/usage/networking/networkpolicy.md
+++ b/docs/usage/networking/networkpolicy.md
@@ -64,7 +64,11 @@ https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/network-po
 
 - `policyTypes`(`list`): There are two supported policyTypes `Ingress` and `Egress`.
 
-- `ingress`(`list`): ingress defines the list of `NetworkPolicyIngressRules`. Each NetworkPolicy may include a list of allowed `ingress` rules. Each rule allows traffic that matches both the `from` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port, from one of three sources, the first specified via an ipBlock, the second and third via different objectSelector.
+- `ingress`(`list`): An Ingress section in a `NetworkPolicy` defines a list of `NetworkPolicyIngressRules` that specify which incoming traffic is allowed. Each `NetworkPolicy` can have multiple ingress rules, and each rule allows traffic that satisfies both the from and ports criteria.
+
+  For example, a `NetworkPolicy` with a single ingress rule may permit traffic on a specific port and only from one of the following sources:
+  - An IP range, defined using an ipBlock.
+  - A set of resources identified by an objectSelector.
 
 - `egress`(`list`): egress defines the list of `NetworkPolicyEgressRules`. Each NetworkPolicy may include a list of allowed egress rules. Each rule allows traffic that matches both `to` and `ports` sections. The example policy contains a single rule, which matches traffic on a single port to any destination in 10.0.0.0/24.
 

--- a/docs/usage/networking/virtualip.md
+++ b/docs/usage/networking/virtualip.md
@@ -39,8 +39,8 @@ If successfully allocated, update the status with the assigned IP address.
 
   for example:
   ```
-  #status:
-  #  ip: 10.0.0.1 # This will be populated by the corresponding controller.
+  status:
+    ip: 10.0.0.1 # This will be populated by the corresponding controller.
   ```
 - **Networking Configuration**: 
     - VM Integration: The allocated VirtualIP is associated with the VM through network configuration mechanisms

--- a/docs/usage/networking/virtualip.md
+++ b/docs/usage/networking/virtualip.md
@@ -1,1 +1,45 @@
 # VirtualIP
+A `Virtual IP (VIP)` in  the `Ironcore` ecosystem is an abstract network resource representing an IP address that is dynamically associated with an `ironcore` `networkInterface`, which in turn is linked to an `ironcore machine/vm`.
+
+# Examaple VirtualIP Resource
+
+```
+apiVersion: networking.ironcore.dev/v1alpha1
+kind: VirtualIP
+metadata:
+  name: virtualip-sample
+spec:
+  type: Public
+  ipFamily: IPv4
+#status:
+#  ip: 10.0.0.1 # This will be populated by the corresponding controller.
+```
+
+# Key Fields
+- **type**(`string`):  Currently supported type is `public`, which allocates and routes a stable public IP.
+
+- **ipFamily**(`string`): `IPFamily` is the ip family of the VirtualIP. Supported values for IPFamily are `IPv4` or `IPv6`.
+
+
+# Reconciliation Process:
+
+- **VirtualIP Creation**: 
+A VirtualIP resource is created, specifying attributes like `ipFamily`: IPv4 or IPv6 and `Type`: public 
+
+- **Reconciliation and IP Assignment**: 
+The VirtualIP reconciler
+Creates or updates a corresponding APINet IP in Ironcore's APINet system.
+Ensures the IP is dynamically allocated and made available for use.
+
+- **Error Handling**:
+If the creation or update of the APINet IP fails, update the VirtualIP status to indicate it is unallocated.
+Requeue the reconciliation to retry the operation.
+
+- **Synchronize Status**:
+Update the VirtualIP status to reflect the actual state of the APINet IP.
+If successfully allocated, update the status with the assigned IP address.
+
+- **Networking Configuration**: 
+    - VM Integration: The allocated VirtualIP is associated with the VM through network configuration mechanisms
+    - Load Balancer Integration: If a load balancer is used, the virtualIP is configured as the frontend IP to route requests to the VM.
+

--- a/docs/usage/networking/virtualip.md
+++ b/docs/usage/networking/virtualip.md
@@ -11,14 +11,12 @@ metadata:
 spec:
   type: Public
   ipFamily: IPv4
-#status:
-#  ip: 10.0.0.1 # This will be populated by the corresponding controller.
 ```
 
 # Key Fields
-- **type**(`string`):  Currently supported type is `public`, which allocates and routes a stable public IP.
+- `type`(`string`):  Currently supported type is `public`, which allocates and routes a stable public IP.
 
-- **ipFamily**(`string`): `IPFamily` is the ip family of the VirtualIP. Supported values for IPFamily are `IPv4` or `IPv6`.
+- `ipFamily`(`string`): `IPFamily` is the ip family of the VirtualIP. Supported values for IPFamily are `IPv4` and `IPv6`.
 
 
 # Reconciliation Process:
@@ -39,6 +37,11 @@ Requeue the reconciliation to retry the operation.
 Update the VirtualIP status to reflect the actual state of the APINet IP.
 If successfully allocated, update the status with the assigned IP address.
 
+  for example:
+  ```
+  #status:
+  #  ip: 10.0.0.1 # This will be populated by the corresponding controller.
+  ```
 - **Networking Configuration**: 
     - VM Integration: The allocated VirtualIP is associated with the VM through network configuration mechanisms
     - Load Balancer Integration: If a load balancer is used, the virtualIP is configured as the frontend IP to route requests to the VM.


### PR DESCRIPTION
- Add usage documentation for `VirtualIP`, `NetworkPolicy`, `NetworkInterface`, and `NATGateway` in network section.
- Add sample yaml and explain key fields for each of the resources
- Describe reconciliation logic for each resource

/ref #1191 