### PR TITLE
Add validation for `Machine` network interface spec

### DIFF
--- a/internal/apis/networking/validation/networkinterface.go
+++ b/internal/apis/networking/validation/networkinterface.go
@@ -21,7 +21,7 @@ func ValidateNetworkInterface(networkInterface *networking.NetworkInterface) fie
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(networkInterface, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, validateNetworkInterfaceSpec(&networkInterface.Spec, &networkInterface.ObjectMeta, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateNetworkInterfaceSpec(&networkInterface.Spec, &networkInterface.ObjectMeta, field.NewPath("spec"))...)
 
 	return allErrs
 }
@@ -37,7 +37,7 @@ func ValidateNetworkInterfaceUpdate(newNetworkInterface, oldNetworkInterface *ne
 	return allErrs
 }
 
-func validateNetworkInterfaceSpec(spec *networking.NetworkInterfaceSpec, nicMeta *metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
+func ValidateNetworkInterfaceSpec(spec *networking.NetworkInterfaceSpec, nicMeta *metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if spec.NetworkRef == (corev1.LocalObjectReference{}) {


### PR DESCRIPTION
# Proposed Changes

- Add validation for machine spec network interface
(Note: `NetworkInterface`  already has the validation for IP sources length i.e. only single IP is allowed https://github.com/ironcore-dev/ironcore/blob/6bbca962fea8e92b279304acae43c6f67ff2b323/internal/apis/networking/validation/networkinterface.go#L143
added missing validation for machine spec networkInterface which will cover prefixLength validation as well)

Fixes #1186 