### PR TITLE
Add usage docs for IPAM resources

### DIFF
--- a/docs/proposals/01-networking-integration.md
+++ b/docs/proposals/01-networking-integration.md
@@ -9,16 +9,16 @@ status: implementable
 
 authors:
 
-- @adracus
-- @afritzler
+- "@adracus"
+- "@afritzler"
 
 reviewers:
 
-- @adracus
-- @afritzler
-- @MalteJ
-- @guvenc
-- @gehoern
+- "@adracus"
+- "@afritzler"
+- "@MalteJ"
+- "@guvenc"
+- "@gehoern"
 
 ---
 

--- a/docs/proposals/02-machine-console-access.md
+++ b/docs/proposals/02-machine-console-access.md
@@ -9,13 +9,13 @@ status: implementable|implemented
 
 authors:
 
-- @adracus
+- "@adracus"
 
 reviewers:
 
-- @gehoern
-- @afritzler
-- @Gchbg
+- "@gehoern"
+- "@afritzler"
+- "@Gchbg"
 
 ---
 

--- a/docs/proposals/03-loadbalancer.md
+++ b/docs/proposals/03-loadbalancer.md
@@ -9,15 +9,15 @@ status: implementable
 
 authors:
 
-- @gehoern
-- @adracus
+- "@gehoern"
+- "@adracus"
 
 reviewers:
 
-- @MalteJ
-- @adracus
-- @afritzler
-- @guvenc
+- "@MalteJ"
+- "@adracus"
+- "@afritzler"
+- "@guvenc"
 
 ---
 

--- a/docs/proposals/04-nat-gateway.md
+++ b/docs/proposals/04-nat-gateway.md
@@ -9,15 +9,15 @@ status: implementable
 
 authors:
 
-- @gehoern
-- @adracus
+- "@gehoern"
+- "@adracus"
 
 reviewers:
 
-- @MalteJ
-- @adracus
-- @afritzler
-- @guvenc
+- "@MalteJ"
+- "@adracus"
+- "@afritzler"
+- "@guvenc"
 
 ---
 

--- a/docs/proposals/05-object-storage.md
+++ b/docs/proposals/05-object-storage.md
@@ -9,13 +9,13 @@ status: implementable
 
 authors:
 
-- @lukasfrank
-- @gehoern
+- "@lukasfrank"
+- "@gehoern"
 
 reviewers:
 
-- @adracus
-- @MalteJ
+- "@adracus"
+- "@MalteJ"
 
 ---
 

--- a/docs/proposals/07-quota.md
+++ b/docs/proposals/07-quota.md
@@ -9,13 +9,13 @@ status: implementable
 
 authors:
 
-- @adracus
+- "@adracus"
 
 reviewers:
 
-- @afritzler
-- @gehoern
-- @ManuStoessel
+- "@afritzler"
+- "@gehoern"
+- "@ManuStoessel"
 
 ---
 

--- a/docs/usage/ipam/prefix.md
+++ b/docs/usage/ipam/prefix.md
@@ -1,5 +1,5 @@
 # Prefix
-A `Prefix` resource provides a fully integrated IP address management(IPAM) solution for `Ironcore`. It serves as a means to define IP prefixes along with prefix length to a reserved range of IP addresses. It is also possible to define child subnets with the specified prefix length referring to the parent prefix.
+A `Prefix` resource provides a fully integrated IP address management(IPAM) solution for `Ironcore`. It serves as a means to define IP prefixes along with prefix length to a reserved range of IP addresses. It is also possible to define child prefixes with the specified prefix length referring to the parent prefix.
 
 # Example Volume Resource
 An example of how to define a root `Prefix` resource in `Ironcore`
@@ -10,7 +10,7 @@ kind: Prefix
 metadata:
   name: root
   labels:
-    subnet-type: public
+    root-prefix: customer-1
 spec:
   prefix: 10.0.0.0/24
 
@@ -21,13 +21,13 @@ An example of how to define a child `Prefix` resource in `Ironcore`
 apiVersion: ipam.ironcore.dev/v1alpha1
 kind: Prefix
 metadata:
-  name: customer-subnet-1
+  name: child-prefix
 spec:
   ipFamily: IPv4
   prefixLength: 9
   parentSelector:
     matchLabels:
-      subnet-type: public
+      root-prefix: customer-1
 
 ```
 (`Note`: Refer to <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/">E2E Examples</a> for more detailed example on IPAM to understant e2e flow)

--- a/docs/usage/ipam/prefix.md
+++ b/docs/usage/ipam/prefix.md
@@ -1,1 +1,56 @@
 # Prefix
+A `Prefix` resource provides fully integrated IP address management(IPAM) solution for `Ironcore`. It serves as a means to define IP prefix along with prefix size to reserved range of IP addresses. It is also possible to define child subnets with the specified prefix length referring to the parent prefix.
+
+# Example Volume Resource
+An example of how to define a root `Prefix` resource in `Ironcore`
+
+```
+apiVersion: ipam.ironcore.dev/v1alpha1
+kind: Prefix
+metadata:
+  name: root
+  labels:
+    subnet-type: public
+spec:
+  prefix: 10.0.0.0/8
+
+```
+An example of how to define a child `Prefix` resource in `Ironcore`
+
+```
+apiVersion: ipam.ironcore.dev/v1alpha1
+kind: Prefix
+metadata:
+  name: customer-subnet-1
+spec:
+  ipFamily: IPv4
+  prefixLength: 9
+  parentSelector:
+    matchLabels:
+      subnet-type: public
+
+```
+(`Note`: Refer to <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/">E2E Examples</a> for more detailed example on IPAM to understant e2e flow)
+
+# Key Fields:
+
+- `ipFamily`(`string`): `ipFamily` is the IPFamily of the prefix. If unset but `prefix` is set, this can be inferred.
+
+- `prefix` (`string`): 	`prefix` is the IP prefix to allocate for this Prefix.
+
+- `prefixLength` (`int`): `prefixLength` is the length of prefix to allocate for this Prefix.
+
+- `parentRef` (`string`): `parentRef` references the parent to allocate the Prefix from. If `parentRef` and `parentSelector` is empty, the Prefix is considered a root prefix and thus allocated by itself.
+
+- `parentSelector` (`LabelSelector`): `parentSelector` is the LabelSelector to use for determining the parent for this Prefix.
+
+
+# Reconciliation Process:
+
+- **Allocate root prefix**: If `parentRef` and `parentSelector` is empty, the PrefixController reconciler consideres it as a root prefix and allocates by itself and the status is updated as `Allocated`.
+
+- **Allocating sub-prefix**: If `parentRef` or `parentSelector` is set PrefixController lists all the previouslly allocated prefix allocations by parent prefix. Finds all the active allocations and prunes outdated ones. If no existing PrefixAllocation object is found new `PrefixAllocation` object is created for the new prefix to allocate. If prefix allocation is successful status is update to `Allocated` otherwise to `Failed` in PrefixAllocation.
+
+- **Prefix allocation scheduler**: PrefixAllocationScheduler continously watches for Prefix resource and tries to schedule all PrefixAllocation objects for which prefix is not yet allocated. PrefixAllocationScheduler determins suitable prefix for allocation by listing available prefixes based on label filter, namespace and desired IP family. Once suitable prefix is found PrefixAllocation spec.parentRef is updated with selected prefix reference.
+
+Once prefix allocation is successfull for sub-prefix, parent Prefix's status is updated with used prefix IP list.


### PR DESCRIPTION
# Proposed Changes

- Add usage documentation for `Prefix` in ipam section
- Sample example yaml to create each of the resources with keyFields explained
- Reconciliation logic explained
- Fix lint issue in proposal docs

Fixes #1193 