### PR TITLE
Set correct `StreamIdleTimeout` value

### DIFF
--- a/poollet/machinepoollet/iri/streaming/remotecommand/exec.go
+++ b/poollet/machinepoollet/iri/streaming/remotecommand/exec.go
@@ -63,7 +63,7 @@ func setExecHandlerOptionsDefaults(o *ExecHandlerOptions) {
 		o.SupportedStreamProtocols = remotecommandconsts.SupportedStreamingProtocols
 	}
 	if o.StreamIdleTimeout == 0 {
-		o.StreamCreationTimeout = 4 * time.Hour
+		o.StreamIdleTimeout = 4 * time.Hour
 	}
 	if o.StreamCreationTimeout == 0 {
 		o.StreamCreationTimeout = remotecommandconsts.DefaultStreamCreationTimeout


### PR DESCRIPTION
# Proposed Changes

- Set correct default value  for streamIdleTimeout in ExecHandlerOptions

Fixes #1242 