### PR TITLE
Extend `BucketStatus` to persist lower layer `bucketID`

### DIFF
--- a/api/storage/v1alpha1/bucket_types.go
+++ b/api/storage/v1alpha1/bucket_types.go
@@ -34,6 +34,8 @@ type BucketAccess struct {
 
 // BucketStatus defines the observed state of Bucket
 type BucketStatus struct {
+	// BucketID is the provider specific bucket ID in the format '<type>://<bucket_id>'.
+	BucketID string `json:"bucketID,omitempty"`
 	// State represents the infrastructure state of a Bucket.
 	State BucketState `json:"state,omitempty"`
 	// LastStateTransitionTime is the last time the State transitioned between values.

--- a/client-go/applyconfigurations/internal/internal.go
+++ b/client-go/applyconfigurations/internal/internal.go
@@ -1434,6 +1434,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: access
       type:
         namedType: com.github.ironcore-dev.ironcore.api.storage.v1alpha1.BucketAccess
+    - name: bucketID
+      type:
+        scalar: string
     - name: conditions
       type:
         list:

--- a/client-go/applyconfigurations/storage/v1alpha1/bucketstatus.go
+++ b/client-go/applyconfigurations/storage/v1alpha1/bucketstatus.go
@@ -13,6 +13,7 @@ import (
 // BucketStatusApplyConfiguration represents a declarative configuration of the BucketStatus type for use
 // with apply.
 type BucketStatusApplyConfiguration struct {
+	BucketID                *string                             `json:"bucketID,omitempty"`
 	State                   *storagev1alpha1.BucketState        `json:"state,omitempty"`
 	LastStateTransitionTime *v1.Time                            `json:"lastStateTransitionTime,omitempty"`
 	Access                  *BucketAccessApplyConfiguration     `json:"access,omitempty"`
@@ -23,6 +24,14 @@ type BucketStatusApplyConfiguration struct {
 // apply.
 func BucketStatus() *BucketStatusApplyConfiguration {
 	return &BucketStatusApplyConfiguration{}
+}
+
+// WithBucketID sets the BucketID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the BucketID field is set to the value of the last call.
+func (b *BucketStatusApplyConfiguration) WithBucketID(value string) *BucketStatusApplyConfiguration {
+	b.BucketID = &value
+	return b
 }
 
 // WithState sets the State field in the declarative configuration to the given value

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -5142,6 +5142,13 @@ func schema_ironcore_api_storage_v1alpha1_BucketStatus(ref common.ReferenceCallb
 				Description: "BucketStatus defines the observed state of Bucket",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"bucketID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BucketID is the provider specific bucket ID in the format '<type>://<bucket_id>'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
 							Description: "State represents the infrastructure state of a Bucket.",

--- a/internal/apis/storage/bucket_types.go
+++ b/internal/apis/storage/bucket_types.go
@@ -34,6 +34,8 @@ type BucketAccess struct {
 
 // BucketStatus defines the observed state of Bucket
 type BucketStatus struct {
+	// BucketID is the provider specific bucket ID in the format '<type>://<bucket_id>'.
+	BucketID string
 	// State represents the infrastructure state of a Bucket.
 	State BucketState
 	// LastStateTransitionTime is the last time the State transitioned between values.

--- a/internal/apis/storage/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/storage/v1alpha1/zz_generated.conversion.go
@@ -587,6 +587,7 @@ func Convert_storage_BucketSpec_To_v1alpha1_BucketSpec(in *storage.BucketSpec, o
 }
 
 func autoConvert_v1alpha1_BucketStatus_To_storage_BucketStatus(in *storagev1alpha1.BucketStatus, out *storage.BucketStatus, s conversion.Scope) error {
+	out.BucketID = in.BucketID
 	out.State = storage.BucketState(in.State)
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
 	out.Access = (*storage.BucketAccess)(unsafe.Pointer(in.Access))
@@ -600,6 +601,7 @@ func Convert_v1alpha1_BucketStatus_To_storage_BucketStatus(in *storagev1alpha1.B
 }
 
 func autoConvert_storage_BucketStatus_To_v1alpha1_BucketStatus(in *storage.BucketStatus, out *storagev1alpha1.BucketStatus, s conversion.Scope) error {
+	out.BucketID = in.BucketID
 	out.State = storagev1alpha1.BucketState(in.State)
 	out.LastStateTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastStateTransitionTime))
 	out.Access = (*storagev1alpha1.BucketAccess)(unsafe.Pointer(in.Access))

--- a/iri/apis/bucket/bucket.go
+++ b/iri/apis/bucket/bucket.go
@@ -10,6 +10,7 @@ import (
 )
 
 type RuntimeService interface {
+	Version(context.Context, *api.VersionRequest) (*api.VersionResponse, error)
 	ListEvents(context.Context, *api.ListEventsRequest) (*api.ListEventsResponse, error)
 	ListBuckets(context.Context, *api.ListBucketsRequest) (*api.ListBucketsResponse, error)
 	CreateBucket(context.Context, *api.CreateBucketRequest) (*api.CreateBucketResponse, error)

--- a/iri/apis/bucket/v1alpha1/api.pb.go
+++ b/iri/apis/bucket/v1alpha1/api.pb.go
@@ -593,6 +593,105 @@ func (x *ListEventsResponse) GetEvents() []*v1alpha11.Event {
 	return nil
 }
 
+type VersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *VersionRequest) Reset() {
+	*x = VersionRequest{}
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VersionRequest) ProtoMessage() {}
+
+func (x *VersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VersionRequest.ProtoReflect.Descriptor instead.
+func (*VersionRequest) Descriptor() ([]byte, []int) {
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *VersionRequest) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+type VersionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Name of the bucket runtime.
+	RuntimeName string `protobuf:"bytes,1,opt,name=runtime_name,json=runtimeName,proto3" json:"runtime_name,omitempty"`
+	// Version of the bucket runtime. The string must be
+	// semver-compatible.
+	RuntimeVersion string `protobuf:"bytes,2,opt,name=runtime_version,json=runtimeVersion,proto3" json:"runtime_version,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *VersionResponse) Reset() {
+	*x = VersionResponse{}
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VersionResponse) ProtoMessage() {}
+
+func (x *VersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VersionResponse.ProtoReflect.Descriptor instead.
+func (*VersionResponse) Descriptor() ([]byte, []int) {
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *VersionResponse) GetRuntimeName() string {
+	if x != nil {
+		return x.RuntimeName
+	}
+	return ""
+}
+
+func (x *VersionResponse) GetRuntimeVersion() string {
+	if x != nil {
+		return x.RuntimeVersion
+	}
+	return ""
+}
+
 type ListBucketsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Filter        *BucketFilter          `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
@@ -602,7 +701,7 @@ type ListBucketsRequest struct {
 
 func (x *ListBucketsRequest) Reset() {
 	*x = ListBucketsRequest{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[10]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +713,7 @@ func (x *ListBucketsRequest) String() string {
 func (*ListBucketsRequest) ProtoMessage() {}
 
 func (x *ListBucketsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[10]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +726,7 @@ func (x *ListBucketsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBucketsRequest.ProtoReflect.Descriptor instead.
 func (*ListBucketsRequest) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{10}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListBucketsRequest) GetFilter() *BucketFilter {
@@ -646,7 +745,7 @@ type ListBucketsResponse struct {
 
 func (x *ListBucketsResponse) Reset() {
 	*x = ListBucketsResponse{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[11]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -658,7 +757,7 @@ func (x *ListBucketsResponse) String() string {
 func (*ListBucketsResponse) ProtoMessage() {}
 
 func (x *ListBucketsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[11]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -671,7 +770,7 @@ func (x *ListBucketsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBucketsResponse.ProtoReflect.Descriptor instead.
 func (*ListBucketsResponse) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{11}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ListBucketsResponse) GetBuckets() []*Bucket {
@@ -690,7 +789,7 @@ type CreateBucketRequest struct {
 
 func (x *CreateBucketRequest) Reset() {
 	*x = CreateBucketRequest{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[12]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -702,7 +801,7 @@ func (x *CreateBucketRequest) String() string {
 func (*CreateBucketRequest) ProtoMessage() {}
 
 func (x *CreateBucketRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[12]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -715,7 +814,7 @@ func (x *CreateBucketRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBucketRequest.ProtoReflect.Descriptor instead.
 func (*CreateBucketRequest) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{12}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateBucketRequest) GetBucket() *Bucket {
@@ -734,7 +833,7 @@ type CreateBucketResponse struct {
 
 func (x *CreateBucketResponse) Reset() {
 	*x = CreateBucketResponse{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[13]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -746,7 +845,7 @@ func (x *CreateBucketResponse) String() string {
 func (*CreateBucketResponse) ProtoMessage() {}
 
 func (x *CreateBucketResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[13]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -759,7 +858,7 @@ func (x *CreateBucketResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateBucketResponse.ProtoReflect.Descriptor instead.
 func (*CreateBucketResponse) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{13}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *CreateBucketResponse) GetBucket() *Bucket {
@@ -778,7 +877,7 @@ type DeleteBucketRequest struct {
 
 func (x *DeleteBucketRequest) Reset() {
 	*x = DeleteBucketRequest{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[14]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -790,7 +889,7 @@ func (x *DeleteBucketRequest) String() string {
 func (*DeleteBucketRequest) ProtoMessage() {}
 
 func (x *DeleteBucketRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[14]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -803,7 +902,7 @@ func (x *DeleteBucketRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteBucketRequest.ProtoReflect.Descriptor instead.
 func (*DeleteBucketRequest) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{14}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *DeleteBucketRequest) GetBucketId() string {
@@ -821,7 +920,7 @@ type DeleteBucketResponse struct {
 
 func (x *DeleteBucketResponse) Reset() {
 	*x = DeleteBucketResponse{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[15]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -833,7 +932,7 @@ func (x *DeleteBucketResponse) String() string {
 func (*DeleteBucketResponse) ProtoMessage() {}
 
 func (x *DeleteBucketResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[15]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -846,7 +945,7 @@ func (x *DeleteBucketResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteBucketResponse.ProtoReflect.Descriptor instead.
 func (*DeleteBucketResponse) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{15}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{17}
 }
 
 type ListBucketClassesRequest struct {
@@ -857,7 +956,7 @@ type ListBucketClassesRequest struct {
 
 func (x *ListBucketClassesRequest) Reset() {
 	*x = ListBucketClassesRequest{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[16]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -869,7 +968,7 @@ func (x *ListBucketClassesRequest) String() string {
 func (*ListBucketClassesRequest) ProtoMessage() {}
 
 func (x *ListBucketClassesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[16]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -882,7 +981,7 @@ func (x *ListBucketClassesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBucketClassesRequest.ProtoReflect.Descriptor instead.
 func (*ListBucketClassesRequest) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{16}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{18}
 }
 
 type ListBucketClassesResponse struct {
@@ -894,7 +993,7 @@ type ListBucketClassesResponse struct {
 
 func (x *ListBucketClassesResponse) Reset() {
 	*x = ListBucketClassesResponse{}
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[17]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -906,7 +1005,7 @@ func (x *ListBucketClassesResponse) String() string {
 func (*ListBucketClassesResponse) ProtoMessage() {}
 
 func (x *ListBucketClassesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_bucket_v1alpha1_api_proto_msgTypes[17]
+	mi := &file_bucket_v1alpha1_api_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -919,7 +1018,7 @@ func (x *ListBucketClassesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBucketClassesResponse.ProtoReflect.Descriptor instead.
 func (*ListBucketClassesResponse) Descriptor() ([]byte, []int) {
-	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{17}
+	return file_bucket_v1alpha1_api_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListBucketClassesResponse) GetBucketClasses() []*BucketClass {
@@ -974,7 +1073,12 @@ const file_bucket_v1alpha1_api_proto_rawDesc = "" +
 	"\x11ListEventsRequest\x124\n" +
 	"\x06filter\x18\x01 \x01(\v2\x1c.bucket.v1alpha1.EventFilterR\x06filter\"C\n" +
 	"\x12ListEventsResponse\x12-\n" +
-	"\x06events\x18\x01 \x03(\v2\x15.event.v1alpha1.EventR\x06events\"K\n" +
+	"\x06events\x18\x01 \x03(\v2\x15.event.v1alpha1.EventR\x06events\"*\n" +
+	"\x0eVersionRequest\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion\"]\n" +
+	"\x0fVersionResponse\x12!\n" +
+	"\fruntime_name\x18\x01 \x01(\tR\vruntimeName\x12'\n" +
+	"\x0fruntime_version\x18\x02 \x01(\tR\x0eruntimeVersion\"K\n" +
 	"\x12ListBucketsRequest\x125\n" +
 	"\x06filter\x18\x01 \x01(\v2\x1d.bucket.v1alpha1.BucketFilterR\x06filter\"H\n" +
 	"\x13ListBucketsResponse\x121\n" +
@@ -992,8 +1096,9 @@ const file_bucket_v1alpha1_api_proto_rawDesc = "" +
 	"\vBucketState\x12\x12\n" +
 	"\x0eBUCKET_PENDING\x10\x00\x12\x14\n" +
 	"\x10BUCKET_AVAILABLE\x10\x01\x12\x10\n" +
-	"\fBUCKET_ERROR\x10\x022\xf0\x03\n" +
-	"\rBucketRuntime\x12W\n" +
+	"\fBUCKET_ERROR\x10\x022\xc0\x04\n" +
+	"\rBucketRuntime\x12N\n" +
+	"\aVersion\x12\x1f.bucket.v1alpha1.VersionRequest\x1a .bucket.v1alpha1.VersionResponse\"\x00\x12W\n" +
 	"\n" +
 	"ListEvents\x12\".bucket.v1alpha1.ListEventsRequest\x1a#.bucket.v1alpha1.ListEventsResponse\"\x00\x12Z\n" +
 	"\vListBuckets\x12#.bucket.v1alpha1.ListBucketsRequest\x1a$.bucket.v1alpha1.ListBucketsResponse\"\x00\x12]\n" +
@@ -1014,7 +1119,7 @@ func file_bucket_v1alpha1_api_proto_rawDescGZIP() []byte {
 }
 
 var file_bucket_v1alpha1_api_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_bucket_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_bucket_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_bucket_v1alpha1_api_proto_goTypes = []any{
 	(BucketState)(0),                  // 0: bucket.v1alpha1.BucketState
 	(*EventFilter)(nil),               // 1: bucket.v1alpha1.EventFilter
@@ -1027,49 +1132,53 @@ var file_bucket_v1alpha1_api_proto_goTypes = []any{
 	(*BucketAccess)(nil),              // 8: bucket.v1alpha1.BucketAccess
 	(*ListEventsRequest)(nil),         // 9: bucket.v1alpha1.ListEventsRequest
 	(*ListEventsResponse)(nil),        // 10: bucket.v1alpha1.ListEventsResponse
-	(*ListBucketsRequest)(nil),        // 11: bucket.v1alpha1.ListBucketsRequest
-	(*ListBucketsResponse)(nil),       // 12: bucket.v1alpha1.ListBucketsResponse
-	(*CreateBucketRequest)(nil),       // 13: bucket.v1alpha1.CreateBucketRequest
-	(*CreateBucketResponse)(nil),      // 14: bucket.v1alpha1.CreateBucketResponse
-	(*DeleteBucketRequest)(nil),       // 15: bucket.v1alpha1.DeleteBucketRequest
-	(*DeleteBucketResponse)(nil),      // 16: bucket.v1alpha1.DeleteBucketResponse
-	(*ListBucketClassesRequest)(nil),  // 17: bucket.v1alpha1.ListBucketClassesRequest
-	(*ListBucketClassesResponse)(nil), // 18: bucket.v1alpha1.ListBucketClassesResponse
-	nil,                               // 19: bucket.v1alpha1.EventFilter.LabelSelectorEntry
-	nil,                               // 20: bucket.v1alpha1.BucketFilter.LabelSelectorEntry
-	nil,                               // 21: bucket.v1alpha1.BucketAccess.SecretDataEntry
-	(*v1alpha1.ObjectMetadata)(nil),   // 22: meta.v1alpha1.ObjectMetadata
-	(*v1alpha11.Event)(nil),           // 23: event.v1alpha1.Event
+	(*VersionRequest)(nil),            // 11: bucket.v1alpha1.VersionRequest
+	(*VersionResponse)(nil),           // 12: bucket.v1alpha1.VersionResponse
+	(*ListBucketsRequest)(nil),        // 13: bucket.v1alpha1.ListBucketsRequest
+	(*ListBucketsResponse)(nil),       // 14: bucket.v1alpha1.ListBucketsResponse
+	(*CreateBucketRequest)(nil),       // 15: bucket.v1alpha1.CreateBucketRequest
+	(*CreateBucketResponse)(nil),      // 16: bucket.v1alpha1.CreateBucketResponse
+	(*DeleteBucketRequest)(nil),       // 17: bucket.v1alpha1.DeleteBucketRequest
+	(*DeleteBucketResponse)(nil),      // 18: bucket.v1alpha1.DeleteBucketResponse
+	(*ListBucketClassesRequest)(nil),  // 19: bucket.v1alpha1.ListBucketClassesRequest
+	(*ListBucketClassesResponse)(nil), // 20: bucket.v1alpha1.ListBucketClassesResponse
+	nil,                               // 21: bucket.v1alpha1.EventFilter.LabelSelectorEntry
+	nil,                               // 22: bucket.v1alpha1.BucketFilter.LabelSelectorEntry
+	nil,                               // 23: bucket.v1alpha1.BucketAccess.SecretDataEntry
+	(*v1alpha1.ObjectMetadata)(nil),   // 24: meta.v1alpha1.ObjectMetadata
+	(*v1alpha11.Event)(nil),           // 25: event.v1alpha1.Event
 }
 var file_bucket_v1alpha1_api_proto_depIdxs = []int32{
-	19, // 0: bucket.v1alpha1.EventFilter.label_selector:type_name -> bucket.v1alpha1.EventFilter.LabelSelectorEntry
-	20, // 1: bucket.v1alpha1.BucketFilter.label_selector:type_name -> bucket.v1alpha1.BucketFilter.LabelSelectorEntry
+	21, // 0: bucket.v1alpha1.EventFilter.label_selector:type_name -> bucket.v1alpha1.EventFilter.LabelSelectorEntry
+	22, // 1: bucket.v1alpha1.BucketFilter.label_selector:type_name -> bucket.v1alpha1.BucketFilter.LabelSelectorEntry
 	0,  // 2: bucket.v1alpha1.BucketStatus.state:type_name -> bucket.v1alpha1.BucketState
 	8,  // 3: bucket.v1alpha1.BucketStatus.access:type_name -> bucket.v1alpha1.BucketAccess
-	22, // 4: bucket.v1alpha1.Bucket.metadata:type_name -> meta.v1alpha1.ObjectMetadata
+	24, // 4: bucket.v1alpha1.Bucket.metadata:type_name -> meta.v1alpha1.ObjectMetadata
 	3,  // 5: bucket.v1alpha1.Bucket.spec:type_name -> bucket.v1alpha1.BucketSpec
 	4,  // 6: bucket.v1alpha1.Bucket.status:type_name -> bucket.v1alpha1.BucketStatus
 	6,  // 7: bucket.v1alpha1.BucketClass.capabilities:type_name -> bucket.v1alpha1.BucketClassCapabilities
-	21, // 8: bucket.v1alpha1.BucketAccess.secret_data:type_name -> bucket.v1alpha1.BucketAccess.SecretDataEntry
+	23, // 8: bucket.v1alpha1.BucketAccess.secret_data:type_name -> bucket.v1alpha1.BucketAccess.SecretDataEntry
 	1,  // 9: bucket.v1alpha1.ListEventsRequest.filter:type_name -> bucket.v1alpha1.EventFilter
-	23, // 10: bucket.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
+	25, // 10: bucket.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
 	2,  // 11: bucket.v1alpha1.ListBucketsRequest.filter:type_name -> bucket.v1alpha1.BucketFilter
 	5,  // 12: bucket.v1alpha1.ListBucketsResponse.buckets:type_name -> bucket.v1alpha1.Bucket
 	5,  // 13: bucket.v1alpha1.CreateBucketRequest.bucket:type_name -> bucket.v1alpha1.Bucket
 	5,  // 14: bucket.v1alpha1.CreateBucketResponse.bucket:type_name -> bucket.v1alpha1.Bucket
 	7,  // 15: bucket.v1alpha1.ListBucketClassesResponse.bucket_classes:type_name -> bucket.v1alpha1.BucketClass
-	9,  // 16: bucket.v1alpha1.BucketRuntime.ListEvents:input_type -> bucket.v1alpha1.ListEventsRequest
-	11, // 17: bucket.v1alpha1.BucketRuntime.ListBuckets:input_type -> bucket.v1alpha1.ListBucketsRequest
-	13, // 18: bucket.v1alpha1.BucketRuntime.CreateBucket:input_type -> bucket.v1alpha1.CreateBucketRequest
-	15, // 19: bucket.v1alpha1.BucketRuntime.DeleteBucket:input_type -> bucket.v1alpha1.DeleteBucketRequest
-	17, // 20: bucket.v1alpha1.BucketRuntime.ListBucketClasses:input_type -> bucket.v1alpha1.ListBucketClassesRequest
-	10, // 21: bucket.v1alpha1.BucketRuntime.ListEvents:output_type -> bucket.v1alpha1.ListEventsResponse
-	12, // 22: bucket.v1alpha1.BucketRuntime.ListBuckets:output_type -> bucket.v1alpha1.ListBucketsResponse
-	14, // 23: bucket.v1alpha1.BucketRuntime.CreateBucket:output_type -> bucket.v1alpha1.CreateBucketResponse
-	16, // 24: bucket.v1alpha1.BucketRuntime.DeleteBucket:output_type -> bucket.v1alpha1.DeleteBucketResponse
-	18, // 25: bucket.v1alpha1.BucketRuntime.ListBucketClasses:output_type -> bucket.v1alpha1.ListBucketClassesResponse
-	21, // [21:26] is the sub-list for method output_type
-	16, // [16:21] is the sub-list for method input_type
+	11, // 16: bucket.v1alpha1.BucketRuntime.Version:input_type -> bucket.v1alpha1.VersionRequest
+	9,  // 17: bucket.v1alpha1.BucketRuntime.ListEvents:input_type -> bucket.v1alpha1.ListEventsRequest
+	13, // 18: bucket.v1alpha1.BucketRuntime.ListBuckets:input_type -> bucket.v1alpha1.ListBucketsRequest
+	15, // 19: bucket.v1alpha1.BucketRuntime.CreateBucket:input_type -> bucket.v1alpha1.CreateBucketRequest
+	17, // 20: bucket.v1alpha1.BucketRuntime.DeleteBucket:input_type -> bucket.v1alpha1.DeleteBucketRequest
+	19, // 21: bucket.v1alpha1.BucketRuntime.ListBucketClasses:input_type -> bucket.v1alpha1.ListBucketClassesRequest
+	12, // 22: bucket.v1alpha1.BucketRuntime.Version:output_type -> bucket.v1alpha1.VersionResponse
+	10, // 23: bucket.v1alpha1.BucketRuntime.ListEvents:output_type -> bucket.v1alpha1.ListEventsResponse
+	14, // 24: bucket.v1alpha1.BucketRuntime.ListBuckets:output_type -> bucket.v1alpha1.ListBucketsResponse
+	16, // 25: bucket.v1alpha1.BucketRuntime.CreateBucket:output_type -> bucket.v1alpha1.CreateBucketResponse
+	18, // 26: bucket.v1alpha1.BucketRuntime.DeleteBucket:output_type -> bucket.v1alpha1.DeleteBucketResponse
+	20, // 27: bucket.v1alpha1.BucketRuntime.ListBucketClasses:output_type -> bucket.v1alpha1.ListBucketClassesResponse
+	22, // [22:28] is the sub-list for method output_type
+	16, // [16:22] is the sub-list for method input_type
 	16, // [16:16] is the sub-list for extension type_name
 	16, // [16:16] is the sub-list for extension extendee
 	0,  // [0:16] is the sub-list for field type_name
@@ -1086,7 +1195,7 @@ func file_bucket_v1alpha1_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_bucket_v1alpha1_api_proto_rawDesc), len(file_bucket_v1alpha1_api_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   21,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/iri/apis/bucket/v1alpha1/api.proto
+++ b/iri/apis/bucket/v1alpha1/api.proto
@@ -7,6 +7,7 @@ import "meta/v1alpha1/api.proto";
 import "event/v1alpha1/api.proto";
 
 service BucketRuntime {
+  rpc Version(VersionRequest) returns (VersionResponse) {};
   rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {};
   rpc ListBuckets(ListBucketsRequest) returns (ListBucketsResponse) {};
   rpc CreateBucket(CreateBucketRequest) returns (CreateBucketResponse) {};
@@ -69,6 +70,18 @@ message ListEventsRequest {
 
 message ListEventsResponse {
   repeated event.v1alpha1.Event events = 1;
+}
+
+message VersionRequest {
+  string version = 1;
+}
+
+message VersionResponse {
+  // Name of the bucket runtime.
+  string runtime_name = 1;
+  // Version of the bucket runtime. The string must be
+  // semver-compatible.
+  string runtime_version = 2;
 }
 
 message ListBucketsRequest {

--- a/iri/apis/bucket/v1alpha1/api_grpc.pb.go
+++ b/iri/apis/bucket/v1alpha1/api_grpc.pb.go
@@ -20,6 +20,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	BucketRuntime_Version_FullMethodName           = "/bucket.v1alpha1.BucketRuntime/Version"
 	BucketRuntime_ListEvents_FullMethodName        = "/bucket.v1alpha1.BucketRuntime/ListEvents"
 	BucketRuntime_ListBuckets_FullMethodName       = "/bucket.v1alpha1.BucketRuntime/ListBuckets"
 	BucketRuntime_CreateBucket_FullMethodName      = "/bucket.v1alpha1.BucketRuntime/CreateBucket"
@@ -31,6 +32,7 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type BucketRuntimeClient interface {
+	Version(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error)
 	ListEvents(ctx context.Context, in *ListEventsRequest, opts ...grpc.CallOption) (*ListEventsResponse, error)
 	ListBuckets(ctx context.Context, in *ListBucketsRequest, opts ...grpc.CallOption) (*ListBucketsResponse, error)
 	CreateBucket(ctx context.Context, in *CreateBucketRequest, opts ...grpc.CallOption) (*CreateBucketResponse, error)
@@ -44,6 +46,16 @@ type bucketRuntimeClient struct {
 
 func NewBucketRuntimeClient(cc grpc.ClientConnInterface) BucketRuntimeClient {
 	return &bucketRuntimeClient{cc}
+}
+
+func (c *bucketRuntimeClient) Version(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(VersionResponse)
+	err := c.cc.Invoke(ctx, BucketRuntime_Version_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *bucketRuntimeClient) ListEvents(ctx context.Context, in *ListEventsRequest, opts ...grpc.CallOption) (*ListEventsResponse, error) {
@@ -100,6 +112,7 @@ func (c *bucketRuntimeClient) ListBucketClasses(ctx context.Context, in *ListBuc
 // All implementations must embed UnimplementedBucketRuntimeServer
 // for forward compatibility.
 type BucketRuntimeServer interface {
+	Version(context.Context, *VersionRequest) (*VersionResponse, error)
 	ListEvents(context.Context, *ListEventsRequest) (*ListEventsResponse, error)
 	ListBuckets(context.Context, *ListBucketsRequest) (*ListBucketsResponse, error)
 	CreateBucket(context.Context, *CreateBucketRequest) (*CreateBucketResponse, error)
@@ -115,6 +128,9 @@ type BucketRuntimeServer interface {
 // pointer dereference when methods are called.
 type UnimplementedBucketRuntimeServer struct{}
 
+func (UnimplementedBucketRuntimeServer) Version(context.Context, *VersionRequest) (*VersionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
+}
 func (UnimplementedBucketRuntimeServer) ListEvents(context.Context, *ListEventsRequest) (*ListEventsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListEvents not implemented")
 }
@@ -149,6 +165,24 @@ func RegisterBucketRuntimeServer(s grpc.ServiceRegistrar, srv BucketRuntimeServe
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&BucketRuntime_ServiceDesc, srv)
+}
+
+func _BucketRuntime_Version_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(VersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BucketRuntimeServer).Version(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: BucketRuntime_Version_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BucketRuntimeServer).Version(ctx, req.(*VersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _BucketRuntime_ListEvents_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -248,6 +282,10 @@ var BucketRuntime_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "bucket.v1alpha1.BucketRuntime",
 	HandlerType: (*BucketRuntimeServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Version",
+			Handler:    _BucketRuntime_Version_Handler,
+		},
 		{
 			MethodName: "ListEvents",
 			Handler:    _BucketRuntime_ListEvents_Handler,

--- a/iri/remote/bucket/runtime.go
+++ b/iri/remote/bucket/runtime.go
@@ -30,6 +30,9 @@ func NewRemoteRuntime(endpoint string) (bucket.RuntimeService, error) {
 	}, nil
 }
 
+func (r *remoteRuntime) Version(ctx context.Context, req *iri.VersionRequest) (*iri.VersionResponse, error) {
+	return r.client.Version(ctx, req)
+}
 func (r *remoteRuntime) ListEvents(ctx context.Context, req *iri.ListEventsRequest) (*iri.ListEventsResponse, error) {
 	return r.client.ListEvents(ctx, req)
 }

--- a/iri/testing/bucket/fake.go
+++ b/iri/testing/bucket/fake.go
@@ -17,6 +17,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var (
+	// FakeVersion is the version of the fake runtime.
+	FakeVersion = "0.1.0"
+
+	// FakeRuntimeName is the name of the fake runtime.
+	FakeRuntimeName = "fakeRuntime"
+)
+
 type FakeBucket struct {
 	*iri.Bucket
 }
@@ -86,6 +94,13 @@ func (r *FakeRuntimeService) ListEvents(ctx context.Context, req *iri.ListEvents
 	}
 
 	return &iri.ListEventsResponse{Events: res}, nil
+}
+
+func (r *FakeRuntimeService) Version(ctx context.Context, req *iri.VersionRequest) (*iri.VersionResponse, error) {
+	return &iri.VersionResponse{
+		RuntimeName:    FakeRuntimeName,
+		RuntimeVersion: FakeVersion,
+	}, nil
 }
 
 func (r *FakeRuntimeService) ListBuckets(ctx context.Context, req *iri.ListBucketsRequest) (*iri.ListBucketsResponse, error) {

--- a/poollet/bucketpoollet/bem/bem_test.go
+++ b/poollet/bucketpoollet/bem/bem_test.go
@@ -71,6 +71,7 @@ var _ = Describe("BucketEventMapper", func() {
 			EventRecorder:     &record.FakeRecorder{},
 			Client:            k8sManager.GetClient(),
 			BucketRuntime:     srv,
+			BucketRuntimeName: fakebucket.FakeRuntimeName,
 			BucketClassMapper: bucketClassMapper,
 			BucketPoolName:    bp.Name,
 		}).SetupWithManager(k8sManager)).To(Succeed())

--- a/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
+++ b/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
@@ -269,6 +269,10 @@ func Run(ctx context.Context, opts Options) error {
 		}
 	}
 
+	version, err := bucketRuntime.Version(ctx, &iri.VersionRequest{})
+	if err != nil {
+		return fmt.Errorf("error getting bucket runtime version: %w", err)
+	}
 	bucketClassMapper := bcm.NewGeneric(bucketRuntime, bcm.GenericOptions{})
 	if err := mgr.Add(bucketClassMapper); err != nil {
 		return fmt.Errorf("error adding bucket class mapper: %w", err)
@@ -310,6 +314,7 @@ func Run(ctx context.Context, opts Options) error {
 			Client:                  mgr.GetClient(),
 			Scheme:                  scheme,
 			BucketRuntime:           bucketRuntime,
+			BucketRuntimeName:       version.RuntimeName,
 			BucketClassMapper:       bucketClassMapper,
 			BucketPoolName:          opts.BucketPoolName,
 			WatchFilterValue:        opts.WatchFilterValue,

--- a/poollet/bucketpoollet/controllers/bucket_controller_test.go
+++ b/poollet/bucketpoollet/controllers/bucket_controller_test.go
@@ -8,7 +8,10 @@ import (
 
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
+	testingbucket "github.com/ironcore-dev/ironcore/iri/testing/bucket"
 	ironcoreclient "github.com/ironcore-dev/ironcore/utils/client"
+	poolletproviderid "github.com/ironcore-dev/ironcore/utils/poollet"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -62,8 +65,11 @@ var _ = Describe("BucketController", func() {
 
 		Expect(ironcoreclient.PatchAddReconcileAnnotation(ctx, k8sClient, bucket)).Should(Succeed())
 
+		By("Waiting for the ironcore bucket Status to be up-to-date")
+		expectedBucketID := poolletproviderid.MakeID(testingbucket.FakeRuntimeName, iriBucket.Metadata.Id)
 		Eventually(Object(bucket)).Should(SatisfyAll(
 			HaveField("Status.State", storagev1alpha1.BucketStateAvailable),
+			HaveField("Status.BucketID", expectedBucketID.String()),
 			HaveField("Status.Access.SecretRef", Not(BeNil())),
 			HaveField("Status.Access.Endpoint", Equal(bucketEndpoint)),
 		))

--- a/poollet/bucketpoollet/controllers/controllers_suite_test.go
+++ b/poollet/bucketpoollet/controllers/controllers_suite_test.go
@@ -214,6 +214,7 @@ func SetupTest() (*corev1.Namespace, *storagev1alpha1.BucketPool, *storagev1alph
 			Client:            k8sManager.GetClient(),
 			Scheme:            scheme.Scheme,
 			BucketRuntime:     srv,
+			BucketRuntimeName: bucket.FakeRuntimeName,
 			BucketClassMapper: bucketClassMapper,
 			BucketPoolName:    bp.Name,
 		}).SetupWithManager(k8sManager)).To(Succeed())


### PR DESCRIPTION
# Proposed Changes

- Extend `BucketStatus` Type to have the lower layer `BucketID`
- Extend IRI Bucket `RuntimeService` interface with `Version()` method implementation
- Validate the changes with a test

/ref #1282 