### PR TITLE
Ignore deleted `Machines` from listing of events and refactor error logging

### DIFF
--- a/broker/machinebroker/server/machine_annotations_update.go
+++ b/broker/machinebroker/server/machine_annotations_update.go
@@ -19,7 +19,7 @@ func (s *Server) UpdateMachineAnnotations(ctx context.Context, req *iri.UpdateMa
 	log.V(1).Info("Getting ironcore machine")
 	aggIronCoreMachine, err := s.getAggregateIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	base := aggIronCoreMachine.Machine.DeepCopy()

--- a/broker/machinebroker/server/machine_delete.go
+++ b/broker/machinebroker/server/machine_delete.go
@@ -19,7 +19,7 @@ func (s *Server) DeleteMachine(ctx context.Context, req *iri.DeleteMachineReques
 
 	ironcoreMachine, err := s.getAggregateIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	log.V(1).Info("Deleting ironcore machine")

--- a/broker/machinebroker/server/machine_networkinterface_attach.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach.go
@@ -119,7 +119,7 @@ func (s *Server) AttachNetworkInterface(ctx context.Context, req *iri.AttachNetw
 	log.V(1).Info("Getting aggregate ironcore machine")
 	ironcoreMachine, err := s.getIronCoreMachine(ctx, req.MachineId)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	idx := ironcoreMachineNetworkInterfaceIndex(ironcoreMachine, networkInterfaceName)

--- a/broker/machinebroker/server/machine_networkinterface_detach.go
+++ b/broker/machinebroker/server/machine_networkinterface_detach.go
@@ -27,7 +27,7 @@ func (s *Server) DetachNetworkInterface(
 	log.V(1).Info("Getting ironcore machine")
 	ironcoreMachine, err := s.getIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	idx := ironcoreMachineNetworkInterfaceIndex(ironcoreMachine, nicName)

--- a/broker/machinebroker/server/machine_powerstate_update.go
+++ b/broker/machinebroker/server/machine_powerstate_update.go
@@ -18,7 +18,7 @@ func (s *Server) UpdateMachinePower(ctx context.Context, req *iri.UpdateMachineP
 	log.V(1).Info("Getting ironcore machine")
 	aggIronCoreMachine, err := s.getAggregateIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	power, err := s.prepareIronCoreMachinePower(req.Power)

--- a/broker/machinebroker/server/machine_volume_attach.go
+++ b/broker/machinebroker/server/machine_volume_attach.go
@@ -238,7 +238,7 @@ func (s *Server) AttachVolume(ctx context.Context, req *iri.AttachVolumeRequest)
 	log.V(1).Info("Getting ironcore machine")
 	ironcoreMachine, err := s.getIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	log.V(1).Info("Getting ironcore volume config")

--- a/broker/machinebroker/server/machine_volume_detach.go
+++ b/broker/machinebroker/server/machine_volume_detach.go
@@ -24,7 +24,7 @@ func (s *Server) DetachVolume(ctx context.Context, req *iri.DetachVolumeRequest)
 	log.V(1).Info("Getting ironcore machine")
 	ironcoreMachine, err := s.getIronCoreMachine(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, convertInternalErrorToGRPC(err)
 	}
 
 	idx := ironcoreMachineVolumeIndex(ironcoreMachine, volumeName)


### PR DESCRIPTION
# Proposed Changes

- Skip already deleted machine from list events
- Improve management of grpc error codes

Fixes #1308 