### PR TITLE
Update `MachineRuntime` to reflect `Machine` stopped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition o
 	./hack/replace.sh config/apiserver/rbac/bucketpool_role.yaml 's/manager-role/storage.ironcore.dev:system:bucketpools/g'
 
 .PHONY: generate
-generate: vgopath models-schema openapi-gen
+generate: vgopath models-schema openapi-gen proto
 	VGOPATH=$(VGOPATH) \
 	MODELS_SCHEMA=$(MODELS_SCHEMA) \
 	OPENAPI_GEN=$(OPENAPI_GEN) \

--- a/iri/apis/machine/v1alpha1/api.pb.go
+++ b/iri/apis/machine/v1alpha1/api.pb.go
@@ -170,6 +170,7 @@ const (
 	MachineState_MACHINE_SUSPENDED   MachineState = 2
 	MachineState_MACHINE_TERMINATED  MachineState = 3
 	MachineState_MACHINE_TERMINATING MachineState = 4
+	MachineState_MACHINE_STOPPED     MachineState = 5
 )
 
 // Enum value maps for MachineState.
@@ -180,6 +181,7 @@ var (
 		2: "MACHINE_SUSPENDED",
 		3: "MACHINE_TERMINATED",
 		4: "MACHINE_TERMINATING",
+		5: "MACHINE_STOPPED",
 	}
 	MachineState_value = map[string]int32{
 		"MACHINE_PENDING":     0,
@@ -187,6 +189,7 @@ var (
 		"MACHINE_SUSPENDED":   2,
 		"MACHINE_TERMINATED":  3,
 		"MACHINE_TERMINATING": 4,
+		"MACHINE_STOPPED":     5,
 	}
 )
 
@@ -2616,13 +2619,14 @@ const file_machine_v1alpha1_api_proto_rawDesc = "" +
 	"\x0fVOLUME_ATTACHED\x10\x01*V\n" +
 	"\x15NetworkInterfaceState\x12\x1d\n" +
 	"\x19NETWORK_INTERFACE_PENDING\x10\x00\x12\x1e\n" +
-	"\x1aNETWORK_INTERFACE_ATTACHED\x10\x01*\x80\x01\n" +
+	"\x1aNETWORK_INTERFACE_ATTACHED\x10\x01*\x95\x01\n" +
 	"\fMachineState\x12\x13\n" +
 	"\x0fMACHINE_PENDING\x10\x00\x12\x13\n" +
 	"\x0fMACHINE_RUNNING\x10\x01\x12\x15\n" +
 	"\x11MACHINE_SUSPENDED\x10\x02\x12\x16\n" +
 	"\x12MACHINE_TERMINATED\x10\x03\x12\x17\n" +
-	"\x13MACHINE_TERMINATING\x10\x042\x8c\v\n" +
+	"\x13MACHINE_TERMINATING\x10\x04\x12\x13\n" +
+	"\x0fMACHINE_STOPPED\x10\x052\x8c\v\n" +
 	"\x0eMachineRuntime\x12P\n" +
 	"\aVersion\x12 .machine.v1alpha1.VersionRequest\x1a!.machine.v1alpha1.VersionResponse\"\x00\x12Y\n" +
 	"\n" +

--- a/iri/apis/machine/v1alpha1/api.proto
+++ b/iri/apis/machine/v1alpha1/api.proto
@@ -136,6 +136,7 @@ enum MachineState {
   MACHINE_SUSPENDED = 2;
   MACHINE_TERMINATED = 3;
   MACHINE_TERMINATING = 4;
+  MACHINE_STOPPED = 5;
 }
 
 message MachineClass {


### PR DESCRIPTION
Right now machines can be:

* pending: currently being provisioned
* running: active and running
* suspended: not running but contains state
* terminated: has been deprovisioned
* terminating: currently being deprovisioned

We are lacking a state that represents a VM that has reached the desired state POWER_OFF. This commit adds the stopped state to reflect that.