### PR TITLE
Fix sporadic test failures in `machinepoollet` test suite

### DIFF
--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -44,6 +44,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, network)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("patching the network to be available")
 		Eventually(UpdateStatus(network, func() {
@@ -59,6 +60,7 @@ var _ = Describe("MachineController", func() {
 			Spec: storagev1alpha1.VolumeSpec{},
 		}
 		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, volume)
 
 		By("patching the volume to be available")
 		Eventually(UpdateStatus(volume, func() {
@@ -108,6 +110,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("waiting for the runtime to report the machine, volume and network interface")
 		Eventually(srv).Should(SatisfyAll(
@@ -185,6 +188,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, network)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("patching the network to be available")
 		Eventually(UpdateStatus(network, func() {
@@ -205,6 +209,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, nic)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, nic)
 
 		By("creating a volume")
 		volume := &storagev1alpha1.Volume{
@@ -215,6 +220,7 @@ var _ = Describe("MachineController", func() {
 			Spec: storagev1alpha1.VolumeSpec{},
 		}
 		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, volume)
 
 		By("patching the volume to be available")
 		Eventually(UpdateStatus(volume, func() {
@@ -257,6 +263,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("waiting for the runtime to report the machine, volume and network interface")
 		Eventually(srv).Should(SatisfyAll(
@@ -342,6 +349,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("waiting for the machine to be created")
 		Eventually(srv).Should(HaveField("Machines", HaveLen(1)))
@@ -372,6 +380,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("waiting for the machine to be created")
 		Eventually(srv).Should(HaveField("Machines", HaveLen(1)))
@@ -424,6 +433,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("By getting ephimeral volume")
 		volumeKey := types.NamespacedName{
@@ -499,6 +509,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, network)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("patching the network to be available")
 		Eventually(UpdateStatus(network, func() {
@@ -519,6 +530,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, nic)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("creating a volume")
 		volume := &storagev1alpha1.Volume{
@@ -529,6 +541,7 @@ var _ = Describe("MachineController", func() {
 			Spec: storagev1alpha1.VolumeSpec{},
 		}
 		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("patching the volume to be available")
 		Eventually(UpdateStatus(volume, func() {
@@ -547,6 +560,7 @@ var _ = Describe("MachineController", func() {
 			Spec: storagev1alpha1.VolumeSpec{},
 		}
 		Expect(k8sClient.Create(ctx, secondaryVolume)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("patching the secondary volume to be available")
 		Eventually(UpdateStatus(secondaryVolume, func() {
@@ -595,6 +609,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, network)
 
 		By("waiting for the runtime to report the machine, volume and network interface")
 		Eventually(srv).Should(SatisfyAll(
@@ -650,6 +665,7 @@ var _ = Describe("MachineController", func() {
 			Spec: storagev1alpha1.VolumeSpec{},
 		}
 		Expect(k8sClient.Create(ctx, volume)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, volume)
 
 		By("patching the volume to be available")
 		Eventually(UpdateStatus(volume, func() {
@@ -684,6 +700,7 @@ var _ = Describe("MachineController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("waiting for the runtime to report the machine with volume")
 		Eventually(srv).Should(SatisfyAll(

--- a/poollet/machinepoollet/controllers/machinepool_controller_test.go
+++ b/poollet/machinepoollet/controllers/machinepool_controller_test.go
@@ -36,6 +36,7 @@ var _ = Describe("MachinePoolController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machineClass2)).To(Succeed(), "failed to create machine class")
+		DeferCleanup(k8sClient.Delete, machineClass2)
 
 		srv.SetMachineClasses([]*testingmachine.FakeMachineClassStatus{
 			{
@@ -71,7 +72,7 @@ var _ = Describe("MachinePoolController", func() {
 		By("checking if the capacity is correct")
 		Eventually(Object(machinePool)).Should(SatisfyAll(
 			HaveField("Status.Capacity", Satisfy(func(capacity corev1alpha1.ResourceList) bool {
-				return quota.Equals(capacity, corev1alpha1.ResourceList{
+				return quota.Contains(capacity, corev1alpha1.ResourceList{
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):  *resource.NewQuantity(machineClassCapacity, resource.DecimalSI),
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity, resource.DecimalSI),
 				})
@@ -94,11 +95,12 @@ var _ = Describe("MachinePoolController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "failed to create machine")
+		DeferCleanup(k8sClient.Delete, machine)
 
 		By("checking if the allocatable resources are correct")
 		Eventually(Object(machinePool)).Should(SatisfyAll(
 			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
-				return quota.Equals(allocatable, corev1alpha1.ResourceList{
+				return quota.Contains(allocatable, corev1alpha1.ResourceList{
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):  *resource.NewQuantity(machineClassCapacity, resource.DecimalSI),
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity-1, resource.DecimalSI),
 				})
@@ -121,11 +123,12 @@ var _ = Describe("MachinePoolController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine2)).To(Succeed(), "failed to create test machine class")
+		DeferCleanup(k8sClient.Delete, machine2)
 
 		By("checking if the allocatable resources are correct")
 		Eventually(Object(machinePool)).Should(SatisfyAll(
 			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
-				return quota.Equals(allocatable, corev1alpha1.ResourceList{
+				return quota.Contains(allocatable, corev1alpha1.ResourceList{
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):  *resource.NewQuantity(machineClassCapacity-1, resource.DecimalSI),
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity-1, resource.DecimalSI),
 				})
@@ -148,6 +151,7 @@ var _ = Describe("MachinePoolController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machineClass)).To(Succeed(), "failed to create test machine class")
+		DeferCleanup(k8sClient.Delete, machineClass)
 
 		srv.SetMachineClasses([]*testingmachine.FakeMachineClassStatus{
 			{
@@ -186,6 +190,7 @@ var _ = Describe("MachinePoolController", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machineClass2)).To(Succeed(), "failed to create test machine class")
+		DeferCleanup(k8sClient.Delete, machineClass2)
 
 		Eventually(Object(machinePool)).Should(SatisfyAll(
 			HaveField("Status.AvailableMachineClasses", HaveLen(1))),

--- a/poollet/machinepoollet/mem/mem_test.go
+++ b/poollet/machinepoollet/mem/mem_test.go
@@ -111,6 +111,7 @@ var _ = Describe("MachineEventMapper", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
 		By("waiting for the runtime to report the machine, volume and network interface")
 		Eventually(srv).Should(SatisfyAll(
 			HaveField("Machines", HaveLen(1)),

--- a/utils/quota/quota.go
+++ b/utils/quota/quota.go
@@ -32,6 +32,21 @@ func Equals(a corev1alpha1.ResourceList, b corev1alpha1.ResourceList) bool {
 	return true
 }
 
+// Contains returns true if first list contains all of second list
+func Contains(a corev1alpha1.ResourceList, b corev1alpha1.ResourceList) bool {
+	for key, value1 := range b {
+		value2, found := a[key]
+		if !found {
+			return false
+		}
+		if value1.Cmp(value2) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 // LessThanOrEqual returns true if a < b for each key in b
 // If false, it returns the keys in a that exceeded b
 func LessThanOrEqual(a corev1alpha1.ResourceList, b corev1alpha1.ResourceList) (bool, sets.Set[corev1alpha1.ResourceName]) {


### PR DESCRIPTION
# Proposed Changes

- As common `MachinePool` is being used across all controller package testcases, sometime MachineClasses attached to the pool are not yet deleted and we are doing equal comparison of list of resources, which is causing test case to fail sometimes.
- Instead of equal added contains check to see if MachinePool contains  newly created MachineClasses with expected quantity 


Fixes #1323 