### PR TITLE
Update volume status received from IRI response

### DIFF
--- a/internal/apis/compute/validation/machine_test.go
+++ b/internal/apis/compute/validation/machine_test.go
@@ -474,5 +474,35 @@ var _ = Describe("Machine", func() {
 			&compute.Machine{},
 			Not(ContainElement(ImmutableField("spec.machinePoolRef"))),
 		),
+		Entry("duplicate volume name",
+			&compute.Machine{
+				Spec: compute.MachineSpec{
+					Volumes: []compute.Volume{
+						{Name: "foo"},
+						{Name: "bar"},
+					},
+				},
+				Status: compute.MachineStatus{
+					Volumes: []compute.VolumeStatus{
+						{Name: "foo"},
+						{Name: "bar"},
+					},
+				},
+			},
+			&compute.Machine{
+				Spec: compute.MachineSpec{
+					Volumes: []compute.Volume{
+						{Name: "foo"},
+					},
+				},
+				Status: compute.MachineStatus{
+					Volumes: []compute.VolumeStatus{
+						{Name: "foo"},
+						{Name: "bar"},
+					},
+				},
+			},
+			ContainElement(DuplicateField("spec.volume[1].name")),
+		),
 	)
 })


### PR DESCRIPTION
# Proposed Changes

- Update volume status received from IRI response, instead of updating status only for volume list available in spec. In case of previous operation failures(like detach volume) will be missed in that case.
- Add validation to check duplicate volume from status as well, in case of volume is removed from spec, but it has failed while detaching. So that user doesn't try to attach volume with same name again.


Fixes #1338  #982 