### PR TITLE
Add `downwardAPILabel` support for `Network` and updated for `NetworkInterface` resource

### DIFF
--- a/broker/bucketbroker/server/bucket_create.go
+++ b/broker/bucketbroker/server/bucket_create.go
@@ -16,7 +16,7 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
 	bucketpoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/bucketpoollet/api/v1alpha1"
 
-	"github.com/ironcore-dev/ironcore/utils/maps"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +43,7 @@ func (s *Server) getIronCoreBucketConfig(_ context.Context, bucket *iri.Bucket) 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: s.namespace,
 			Name:      s.generateID(),
-			Labels: maps.AppendMap(labels, map[string]string{
+			Labels: utilsmaps.AppendMap(labels, map[string]string{
 				bucketbrokerv1alpha1.ManagerLabel: bucketbrokerv1alpha1.BucketBrokerManager,
 			}),
 		},

--- a/broker/common/utils/utils.go
+++ b/broker/common/utils/utils.go
@@ -6,6 +6,8 @@ package utils
 import (
 	"context"
 
+	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,4 +56,23 @@ func ClientObjectGetter[ObjPtr ObjectPtr[Obj], Obj any](
 		}
 		return objPtr, nil
 	}
+}
+
+func PrepareDownwardAPILabels(
+	labelSource map[string]string,
+	downwardAPILabels map[string]string,
+	prefix string,
+) map[string]string {
+	preparedLabels := make(map[string]string)
+	for downwardAPILabelName, defaultLabelName := range downwardAPILabels {
+		key := poolletutils.DownwardAPILabel(prefix, downwardAPILabelName)
+		value := labelSource[key]
+		if value == "" {
+			value = labelSource[defaultLabelName]
+		}
+		if value != "" {
+			preparedLabels[key] = value
+		}
+	}
+	return preparedLabels
 }

--- a/broker/machinebroker/apiutils/apiutils.go
+++ b/broker/machinebroker/apiutils/apiutils.go
@@ -167,11 +167,3 @@ func IsManagedBy(o metav1.Object, manager string) bool {
 	actual, ok := o.GetLabels()[machinebrokerv1alpha1.ManagerLabel]
 	return ok && actual == manager
 }
-
-func MustMarshalJSON(v interface{}) string {
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
-}

--- a/broker/machinebroker/apiutils/apiutils.go
+++ b/broker/machinebroker/apiutils/apiutils.go
@@ -167,3 +167,11 @@ func IsManagedBy(o metav1.Object, manager string) bool {
 	actual, ok := o.GetLabels()[machinebrokerv1alpha1.ManagerLabel]
 	return ok && actual == manager
 }
+
+func MustMarshalJSON(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/broker/machinebroker/networks/networks.go
+++ b/broker/machinebroker/networks/networks.go
@@ -14,7 +14,7 @@ import (
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/cluster"
-	"github.com/ironcore-dev/ironcore/utils/maps"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/util/workqueue"
@@ -104,7 +104,7 @@ func (e *Manager) getOrCreateNetworkForProviderID(ctx context.Context, log logr.
 			Annotations: map[string]string{
 				commonv1alpha1.ManagedByAnnotation: machinebrokerv1alpha1.MachineBrokerManager,
 			},
-			Labels: maps.AppendMap(labels, map[string]string{
+			Labels: utilsmaps.AppendMap(labels, map[string]string{
 				machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
 			}),
 		},

--- a/broker/machinebroker/server/machine.go
+++ b/broker/machinebroker/server/machine.go
@@ -9,7 +9,6 @@ import (
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
-	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -169,16 +168,11 @@ func (s *Server) convertIronCoreNetworkInterfaceAttachment(
 			return nil, err
 		}
 
-		labels := ironcoreNic.NetworkInterface.GetLabels()
-		//TODO Remove once labels are not part of API
-		delete(labels, machinebrokerv1alpha1.ManagerLabel)
-
 		return &iri.NetworkInterface{
 			Name:       ironcoreMachineNic.Name,
 			NetworkId:  ironcoreNic.Network.Spec.ProviderID,
 			Ips:        ips,
 			Attributes: ironcoreNic.NetworkInterface.Spec.Attributes,
-			Labels:     labels,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized ironcore machine network interface %#v", ironcoreMachineNic)

--- a/broker/machinebroker/server/machine_create.go
+++ b/broker/machinebroker/server/machine_create.go
@@ -13,12 +13,12 @@ import (
 	"github.com/ironcore-dev/ironcore/broker/common/cleaner"
 	brokerutils "github.com/ironcore-dev/ironcore/broker/common/utils"
 	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -189,7 +189,7 @@ func (s *Server) createIronCoreMachine(
 			Namespace:   s.cluster.Namespace(),
 			Name:        s.cluster.IDGen().Generate(),
 			Annotations: cfg.Annotations,
-			Labels: maps.AppendMap(cfg.Labels, map[string]string{
+			Labels: utilsmaps.AppendMap(cfg.Labels, map[string]string{
 				machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
 			}),
 		},

--- a/broker/machinebroker/server/machine_create.go
+++ b/broker/machinebroker/server/machine_create.go
@@ -11,11 +11,11 @@ import (
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/common/cleaner"
+	brokerutils "github.com/ironcore-dev/ironcore/broker/common/utils"
 	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
+
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
-
-	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/maps"
@@ -50,22 +50,6 @@ func (s *Server) prepareIronCoreMachinePower(power iri.Power) (computev1alpha1.P
 	default:
 		return "", fmt.Errorf("unknown power state %v", power)
 	}
-}
-
-func (s *Server) prepareIronCoreMachineLabels(machine *iri.Machine) map[string]string {
-	labels := make(map[string]string)
-
-	for downwardAPILabelName, defaultLabelName := range s.brokerDownwardAPILabels {
-		value := machine.GetMetadata().GetLabels()[poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, downwardAPILabelName)]
-		if value == "" {
-			value = machine.GetMetadata().GetLabels()[defaultLabelName]
-		}
-		if value != "" {
-			labels[poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, downwardAPILabelName)] = value
-		}
-	}
-
-	return labels
 }
 
 func (s *Server) prepareIronCoreMachineAnnotations(machine *iri.Machine) (map[string]string, error) {
@@ -116,7 +100,11 @@ func (s *Server) getIronCoreMachineConfig(machine *iri.Machine) (*IronCoreMachin
 		ironcoreVolumeCfgs[i] = ironcoreVolumeCfg
 	}
 
-	labels := s.prepareIronCoreMachineLabels(machine)
+	labels := brokerutils.PrepareDownwardAPILabels(
+		machine.GetMetadata().GetLabels(),
+		s.brokerDownwardAPILabels,
+		machinepoolletv1alpha1.MachineDownwardAPIPrefix,
+	)
 	annotations, err := s.prepareIronCoreMachineAnnotations(machine)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing ironcore machine annotations: %w", err)

--- a/broker/machinebroker/server/machine_list.go
+++ b/broker/machinebroker/server/machine_list.go
@@ -107,7 +107,7 @@ func (s *Server) aggregateIronCoreMachine(
 
 			aggIronCoreNic, err := s.aggregateIronCoreNetworkInterface(ctx, rd, ironcoreNic)
 			if err != nil {
-				return nil, fmt.Errorf("error aggregating network interface: %w", err)
+				return nil, fmt.Errorf("error aggregating ironcore network interface %s: %w", ironcoreNic.Name, err)
 			}
 
 			aggIronCoreNics[machineNic.Name] = aggIronCoreNic

--- a/broker/machinebroker/server/machine_networkinterface_attach.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach.go
@@ -91,6 +91,10 @@ func (s *Server) createIronCoreNetworkInterface(
 		return nil, nil, fmt.Errorf("error getting network: %w", err)
 	}
 
+	nicAttributes := maps.Clone(cfg.Attributes)
+	delete(nicAttributes, machinepoolletv1alpha1.NICLabelsAttributeKey)
+	delete(nicAttributes, machinepoolletv1alpha1.NetworkLabelsAttributeKey)
+
 	ironcoreNic := &networkingv1alpha1.NetworkInterface{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: s.cluster.Namespace(),
@@ -108,7 +112,7 @@ func (s *Server) createIronCoreNetworkInterface(
 			MachineRef: s.optionalLocalUIDReference(optIronCoreMachine),
 			IPFamilies: s.getIronCoreIPsIPFamilies(cfg.IPs),
 			IPs:        s.ironcoreIPsToIronCoreIPSources(cfg.IPs),
-			Attributes: cfg.Attributes,
+			Attributes: nicAttributes,
 		},
 	}
 

--- a/broker/machinebroker/server/machine_networkinterface_attach_test.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach_test.go
@@ -8,10 +8,11 @@ import (
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
+	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
+
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/maps"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -55,8 +56,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -83,15 +84,12 @@ var _ = Describe("AttachNetworkInterface", func() {
 		Expect(k8sClient.Get(ctx, nicKey, nic)).To(Succeed())
 
 		By("inspecting the ironcore network interface")
+		Expect(nic.Spec.IPs).To(Equal([]networkingv1alpha1.IPSource{
+			{Value: commonv1alpha1.MustParseNewIP("10.0.0.1")},
+		}))
 		Expect(nic.Labels).To(Equal(map[string]string{
 			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"): "foobar",
 			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
-		}))
-		By("inspecting the ironcore network interface")
-		Expect(nic.Spec.Attributes).To(Not(HaveKey(machinepoolletv1alpha1.NICLabelsAttributeKey)))
-		Expect(nic.Spec.Attributes).To(Not(HaveKey(machinepoolletv1alpha1.NetworkLabelsAttributeKey)))
-		Expect(nic.Spec.IPs).To(Equal([]networkingv1alpha1.IPSource{
-			{Value: commonv1alpha1.MustParseNewIP("10.0.0.1")},
 		}))
 
 		By("getting the referenced ironcore network")
@@ -142,8 +140,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -172,6 +170,10 @@ var _ = Describe("AttachNetworkInterface", func() {
 		By("inspecting the ironcore network interface")
 		Expect(nic.Spec.IPs).To(Equal([]networkingv1alpha1.IPSource{
 			{Value: commonv1alpha1.MustParseNewIP("10.0.0.1")},
+		}))
+		Expect(nic.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"): "foobar",
+			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
 		}))
 
 		By("getting the referenced ironcore network")
@@ -214,8 +216,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())

--- a/broker/machinebroker/server/machine_networkinterface_attach_test.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach_test.go
@@ -11,9 +11,11 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
+	"github.com/ironcore-dev/ironcore/utils/maps"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,17 +41,22 @@ var _ = Describe("AttachNetworkInterface", func() {
 		machineID := createMachineRes.Machine.Metadata.Id
 
 		By("attaching a network interface")
+		nicLabels := map[string]string{
+			machinepoolletv1alpha1.NetworkInterfaceUIDLabel: "foobar",
+		}
+		networkLabels := map[string]string{
+			machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+		}
+
 		Expect(srv.AttachNetworkInterface(ctx, &iri.AttachNetworkInterfaceRequest{
 			MachineId: machineID,
 			NetworkInterface: &iri.NetworkInterface{
 				Name:      "my-nic",
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
-				Labels: map[string]string{
-					machinepoolletv1alpha1.NetworkInterfaceUIDLabel: "foobar",
-				},
-				NetworkLabels: map[string]string{
-					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				Attributes: map[string]string{
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -120,14 +127,21 @@ var _ = Describe("AttachNetworkInterface", func() {
 		machineID := createMachineRes.Machine.Metadata.Id
 
 		By("attaching a network interface")
+		nicLabels := map[string]string{
+			machinepoolletv1alpha1.NetworkInterfaceUIDLabel: "foobar",
+		}
+		networkLabels := map[string]string{
+			machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+		}
 		Expect(srv.AttachNetworkInterface(ctx, &iri.AttachNetworkInterfaceRequest{
 			MachineId: machineID,
 			NetworkInterface: &iri.NetworkInterface{
 				Name:      "my-nic",
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
-				NetworkLabels: map[string]string{
-					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				Attributes: map[string]string{
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -197,8 +211,9 @@ var _ = Describe("AttachNetworkInterface", func() {
 				Name:      "my-nic",
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
-				NetworkLabels: map[string]string{
-					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				Attributes: map[string]string{
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())

--- a/broker/machinebroker/server/machine_networkinterface_attach_test.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach_test.go
@@ -4,12 +4,12 @@
 package server_test
 
 import (
+	"encoding/json"
+
 	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	machinebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/machinebroker/api/v1alpha1"
-	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
-
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
@@ -56,8 +56,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(mustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(mustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -140,8 +140,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(mustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(mustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -216,8 +216,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
 				Attributes: map[string]string{
-					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(apiutils.MustMarshalJSON(nicLabels)),
-					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(apiutils.MustMarshalJSON(networkLabels)),
+					machinepoolletv1alpha1.NICLabelsAttributeKey:     string(mustMarshalJSON(nicLabels)),
+					machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(mustMarshalJSON(networkLabels)),
 				},
 			},
 		})).Error().NotTo(HaveOccurred())
@@ -235,3 +235,11 @@ var _ = Describe("AttachNetworkInterface", func() {
 		}))
 	})
 })
+
+func mustMarshalJSON(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}

--- a/broker/machinebroker/server/machine_networkinterface_attach_test.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach_test.go
@@ -48,6 +48,9 @@ var _ = Describe("AttachNetworkInterface", func() {
 				Labels: map[string]string{
 					machinepoolletv1alpha1.NetworkInterfaceUIDLabel: "foobar",
 				},
+				NetworkLabels: map[string]string{
+					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				},
 			},
 		})).Error().NotTo(HaveOccurred())
 
@@ -94,6 +97,10 @@ var _ = Describe("AttachNetworkInterface", func() {
 		Expect(network.Status).To(Equal(networkingv1alpha1.NetworkStatus{
 			State: networkingv1alpha1.NetworkStateAvailable,
 		}))
+		Expect(network.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"): "bar",
+			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
+		}))
 	})
 
 	It("should correctly re-create a network in case it has been removed", func(ctx SpecContext) {
@@ -119,6 +126,9 @@ var _ = Describe("AttachNetworkInterface", func() {
 				Name:      "my-nic",
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
+				NetworkLabels: map[string]string{
+					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				},
 			},
 		})).Error().NotTo(HaveOccurred())
 
@@ -160,6 +170,10 @@ var _ = Describe("AttachNetworkInterface", func() {
 		Expect(network.Status).To(Equal(networkingv1alpha1.NetworkStatus{
 			State: networkingv1alpha1.NetworkStateAvailable,
 		}))
+		Expect(network.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"): "bar",
+			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
+		}))
 
 		By("detaching the network interface")
 		Expect(srv.DetachNetworkInterface(ctx, &iri.DetachNetworkInterfaceRequest{
@@ -183,6 +197,9 @@ var _ = Describe("AttachNetworkInterface", func() {
 				Name:      "my-nic",
 				NetworkId: "network-id",
 				Ips:       []string{"10.0.0.1"},
+				NetworkLabels: map[string]string{
+					machinepoolletv1alpha1.NetworkUIDLabel: "bar",
+				},
 			},
 		})).Error().NotTo(HaveOccurred())
 
@@ -192,6 +209,10 @@ var _ = Describe("AttachNetworkInterface", func() {
 		}))
 		Expect(network.Status).To(Equal(networkingv1alpha1.NetworkStatus{
 			State: networkingv1alpha1.NetworkStateAvailable,
+		}))
+		Expect(network.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"): "bar",
+			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
 		}))
 	})
 })

--- a/broker/machinebroker/server/machine_networkinterface_attach_test.go
+++ b/broker/machinebroker/server/machine_networkinterface_attach_test.go
@@ -88,6 +88,8 @@ var _ = Describe("AttachNetworkInterface", func() {
 			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
 		}))
 		By("inspecting the ironcore network interface")
+		Expect(nic.Spec.Attributes).To(Not(HaveKey(machinepoolletv1alpha1.NICLabelsAttributeKey)))
+		Expect(nic.Spec.Attributes).To(Not(HaveKey(machinepoolletv1alpha1.NetworkLabelsAttributeKey)))
 		Expect(nic.Spec.IPs).To(Equal([]networkingv1alpha1.IPSource{
 			{Value: commonv1alpha1.MustParseNewIP("10.0.0.1")},
 		}))

--- a/broker/machinebroker/server/networkinterface.go
+++ b/broker/machinebroker/server/networkinterface.go
@@ -45,7 +45,7 @@ func (s *Server) aggregateIronCoreNetworkInterface(
 	ironcoreNetwork := &networkingv1alpha1.Network{}
 	ironcoreNetworkKey := client.ObjectKey{Namespace: s.cluster.Namespace(), Name: ironcoreNic.Spec.NetworkRef.Name}
 	if err := rd.Get(ctx, ironcoreNetworkKey, ironcoreNetwork); err != nil {
-		return nil, fmt.Errorf("error getting ironcore network %s: %w", ironcoreNic.Name, err)
+		return nil, fmt.Errorf("error getting ironcore network: %w", err)
 	}
 
 	return &AggregateIronCoreNetworkInterface{

--- a/broker/machinebroker/server/server_suite_test.go
+++ b/broker/machinebroker/server/server_suite_test.go
@@ -138,6 +138,7 @@ func SetupTest() (*corev1.Namespace, *server.Server) {
 			BrokerDownwardAPILabels: map[string]string{
 				"root-machine-uid": machinepoolletv1alpha1.MachineUIDLabel,
 				"root-nic-uid":     machinepoolletv1alpha1.NetworkInterfaceUIDLabel,
+				"root-network-uid": machinepoolletv1alpha1.NetworkUIDLabel,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/broker/volumebroker/server/volume_create.go
+++ b/broker/volumebroker/server/volume_create.go
@@ -17,7 +17,7 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 
-	"github.com/ironcore-dev/ironcore/utils/maps"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,7 +70,7 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: s.namespace,
 			Name:      s.idGen.Generate(),
-			Labels: maps.AppendMap(labels, map[string]string{
+			Labels: utilsmaps.AppendMap(labels, map[string]string{
 				volumebrokerv1alpha1.ManagerLabel: volumebrokerv1alpha1.VolumeBrokerManager,
 			}),
 		},

--- a/broker/volumebroker/server/volume_create.go
+++ b/broker/volumebroker/server/volume_create.go
@@ -10,10 +10,11 @@ import (
 	"github.com/go-logr/logr"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
+	brokerutils "github.com/ironcore-dev/ironcore/broker/common/utils"
 	volumebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/volumebroker/api/v1alpha1"
+
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
-	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 
 	"github.com/ironcore-dev/ironcore/utils/maps"
@@ -27,22 +28,6 @@ type AggregateIronCoreVolume struct {
 	Volume           *storagev1alpha1.Volume
 	EncryptionSecret *corev1.Secret
 	AccessSecret     *corev1.Secret
-}
-
-func (s *Server) prepareIronCoreVolumeLabels(volume *iri.Volume) map[string]string {
-	labels := make(map[string]string)
-
-	for downwardAPILabelName, defaultLabelName := range s.brokerDownwardAPILabels {
-		value := volume.GetMetadata().GetLabels()[poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, downwardAPILabelName)]
-		if value == "" {
-			value = volume.GetMetadata().GetLabels()[defaultLabelName]
-		}
-		if value != "" {
-			labels[poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, downwardAPILabelName)] = value
-		}
-	}
-
-	return labels
 }
 
 func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) (*AggregateIronCoreVolume, error) {
@@ -75,7 +60,11 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 		}
 	}
 
-	labels := s.prepareIronCoreVolumeLabels(volume)
+	labels := brokerutils.PrepareDownwardAPILabels(
+		volume.GetMetadata().GetLabels(),
+		s.brokerDownwardAPILabels,
+		volumepoolletv1alpha1.VolumeDownwardAPIPrefix,
+	)
 
 	ironcoreVolume := &storagev1alpha1.Volume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/config/machinepoollet-broker/manager/manager.yaml
+++ b/config/machinepoollet-broker/manager/manager.yaml
@@ -38,6 +38,9 @@ spec:
         - --nic-downward-api-label=root-nic-namespace=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-nic-namespace']
         - --nic-downward-api-label=root-nic-name=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-nic-name']
         - --nic-downward-api-label=root-nic-uid=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-nic-uid']
+        - --network-downward-api-label=root-network-namespace=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-network-namespace']
+        - --network-downward-api-label=root-network-name=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-network-name']
+        - --network-downward-api-label=root-network-uid=metadata.labels['downward-api.machinepoollet.ironcore.dev/root-network-uid']
         image: machinepoollet:latest
         env:
         - name: KUBERNETES_SERVICE_NAME
@@ -86,6 +89,9 @@ spec:
         - --broker-downward-api-label=root-nic-namespace=machinepoollet.ironcore.dev/nic-namespace
         - --broker-downward-api-label=root-nic-name=machinepoollet.ironcore.dev/nic-name
         - --broker-downward-api-label=root-nic-uid=machinepoollet.ironcore.dev/nic-uid
+        - --broker-downward-api-label=root-network-namespace=machinepoollet.ironcore.dev/network-namespace
+        - --broker-downward-api-label=root-network-name=machinepoollet.ironcore.dev/network-name
+        - --broker-downward-api-label=root-network-uid=machinepoollet.ironcore.dev/network-uid
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/iri/apis/machine/v1alpha1/api.pb.go
+++ b/iri/apis/machine/v1alpha1/api.pb.go
@@ -758,8 +758,6 @@ type NetworkInterface struct {
 	NetworkId     string                 `protobuf:"bytes,2,opt,name=network_id,json=networkId,proto3" json:"network_id,omitempty"`
 	Ips           []string               `protobuf:"bytes,3,rep,name=ips,proto3" json:"ips,omitempty"`
 	Attributes    map[string]string      `protobuf:"bytes,4,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Labels        map[string]string      `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	NetworkLabels map[string]string      `protobuf:"bytes,6,rep,name=network_labels,json=networkLabels,proto3" json:"network_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Labels specific to the network this interface is attached to
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -818,20 +816,6 @@ func (x *NetworkInterface) GetIps() []string {
 func (x *NetworkInterface) GetAttributes() map[string]string {
 	if x != nil {
 		return x.Attributes
-	}
-	return nil
-}
-
-func (x *NetworkInterface) GetLabels() map[string]string {
-	if x != nil {
-		return x.Labels
-	}
-	return nil
-}
-
-func (x *NetworkInterface) GetNetworkLabels() map[string]string {
-	if x != nil {
-		return x.NetworkLabels
 	}
 	return nil
 }
@@ -2521,7 +2505,7 @@ const file_machine_v1alpha1_api_proto_rawDesc = "" +
 	"empty_disk\x18\x04 \x01(\v2\x1b.machine.v1alpha1.EmptyDiskR\temptyDisk\x12B\n" +
 	"\n" +
 	"connection\x18\x05 \x01(\v2\".machine.v1alpha1.VolumeConnectionR\n" +
-	"connection\"\x8d\x04\n" +
+	"connection\"\xea\x01\n" +
 	"\x10NetworkInterface\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
@@ -2529,16 +2513,8 @@ const file_machine_v1alpha1_api_proto_rawDesc = "" +
 	"\x03ips\x18\x03 \x03(\tR\x03ips\x12R\n" +
 	"\n" +
 	"attributes\x18\x04 \x03(\v22.machine.v1alpha1.NetworkInterface.AttributesEntryR\n" +
-	"attributes\x12F\n" +
-	"\x06labels\x18\x05 \x03(\v2..machine.v1alpha1.NetworkInterface.LabelsEntryR\x06labels\x12\\\n" +
-	"\x0enetwork_labels\x18\x06 \x03(\v25.machine.v1alpha1.NetworkInterface.NetworkLabelsEntryR\rnetworkLabels\x1a=\n" +
+	"attributes\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +
-	"\vLabelsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
-	"\x12NetworkLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x02\n" +
 	"\vMachineSpec\x12-\n" +
@@ -2681,7 +2657,7 @@ func file_machine_v1alpha1_api_proto_rawDescGZIP() []byte {
 }
 
 var file_machine_v1alpha1_api_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_machine_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
+var file_machine_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_machine_v1alpha1_api_proto_goTypes = []any{
 	(Power)(0),                               // 0: machine.v1alpha1.Power
 	(VolumeState)(0),                         // 1: machine.v1alpha1.VolumeState
@@ -2740,11 +2716,9 @@ var file_machine_v1alpha1_api_proto_goTypes = []any{
 	nil,                                      // 54: machine.v1alpha1.VolumeConnection.SecretDataEntry
 	nil,                                      // 55: machine.v1alpha1.VolumeConnection.EncryptionDataEntry
 	nil,                                      // 56: machine.v1alpha1.NetworkInterface.AttributesEntry
-	nil,                                      // 57: machine.v1alpha1.NetworkInterface.LabelsEntry
-	nil,                                      // 58: machine.v1alpha1.NetworkInterface.NetworkLabelsEntry
-	nil,                                      // 59: machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
-	(*v1alpha1.ObjectMetadata)(nil),          // 60: meta.v1alpha1.ObjectMetadata
-	(*v1alpha11.Event)(nil),                  // 61: event.v1alpha1.Event
+	nil,                                      // 57: machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
+	(*v1alpha1.ObjectMetadata)(nil),          // 58: meta.v1alpha1.ObjectMetadata
+	(*v1alpha11.Event)(nil),                  // 59: event.v1alpha1.Event
 }
 var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	48, // 0: machine.v1alpha1.VolumeSpec.attributes:type_name -> machine.v1alpha1.VolumeSpec.AttributesEntry
@@ -2752,7 +2726,7 @@ var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	50, // 2: machine.v1alpha1.MachineFilter.label_selector:type_name -> machine.v1alpha1.MachineFilter.LabelSelectorEntry
 	51, // 3: machine.v1alpha1.EventFilter.label_selector:type_name -> machine.v1alpha1.EventFilter.LabelSelectorEntry
 	52, // 4: machine.v1alpha1.MachineClassCapabilities.resources:type_name -> machine.v1alpha1.MachineClassCapabilities.ResourcesEntry
-	60, // 5: machine.v1alpha1.Machine.metadata:type_name -> meta.v1alpha1.ObjectMetadata
+	58, // 5: machine.v1alpha1.Machine.metadata:type_name -> meta.v1alpha1.ObjectMetadata
 	14, // 6: machine.v1alpha1.Machine.spec:type_name -> machine.v1alpha1.MachineSpec
 	15, // 7: machine.v1alpha1.Machine.status:type_name -> machine.v1alpha1.MachineStatus
 	53, // 8: machine.v1alpha1.VolumeConnection.attributes:type_name -> machine.v1alpha1.VolumeConnection.AttributesEntry
@@ -2761,64 +2735,62 @@ var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	10, // 11: machine.v1alpha1.Volume.empty_disk:type_name -> machine.v1alpha1.EmptyDisk
 	11, // 12: machine.v1alpha1.Volume.connection:type_name -> machine.v1alpha1.VolumeConnection
 	56, // 13: machine.v1alpha1.NetworkInterface.attributes:type_name -> machine.v1alpha1.NetworkInterface.AttributesEntry
-	57, // 14: machine.v1alpha1.NetworkInterface.labels:type_name -> machine.v1alpha1.NetworkInterface.LabelsEntry
-	58, // 15: machine.v1alpha1.NetworkInterface.network_labels:type_name -> machine.v1alpha1.NetworkInterface.NetworkLabelsEntry
-	0,  // 16: machine.v1alpha1.MachineSpec.power:type_name -> machine.v1alpha1.Power
-	9,  // 17: machine.v1alpha1.MachineSpec.image:type_name -> machine.v1alpha1.ImageSpec
-	12, // 18: machine.v1alpha1.MachineSpec.volumes:type_name -> machine.v1alpha1.Volume
-	13, // 19: machine.v1alpha1.MachineSpec.network_interfaces:type_name -> machine.v1alpha1.NetworkInterface
-	3,  // 20: machine.v1alpha1.MachineStatus.state:type_name -> machine.v1alpha1.MachineState
-	16, // 21: machine.v1alpha1.MachineStatus.volumes:type_name -> machine.v1alpha1.VolumeStatus
-	17, // 22: machine.v1alpha1.MachineStatus.network_interfaces:type_name -> machine.v1alpha1.NetworkInterfaceStatus
-	1,  // 23: machine.v1alpha1.VolumeStatus.state:type_name -> machine.v1alpha1.VolumeState
-	2,  // 24: machine.v1alpha1.NetworkInterfaceStatus.state:type_name -> machine.v1alpha1.NetworkInterfaceState
-	7,  // 25: machine.v1alpha1.MachineClass.capabilities:type_name -> machine.v1alpha1.MachineClassCapabilities
-	18, // 26: machine.v1alpha1.MachineClassStatus.machine_class:type_name -> machine.v1alpha1.MachineClass
-	5,  // 27: machine.v1alpha1.ListMachinesRequest.filter:type_name -> machine.v1alpha1.MachineFilter
-	8,  // 28: machine.v1alpha1.ListMachinesResponse.machines:type_name -> machine.v1alpha1.Machine
-	6,  // 29: machine.v1alpha1.ListEventsRequest.filter:type_name -> machine.v1alpha1.EventFilter
-	61, // 30: machine.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
-	8,  // 31: machine.v1alpha1.CreateMachineRequest.machine:type_name -> machine.v1alpha1.Machine
-	8,  // 32: machine.v1alpha1.CreateMachineResponse.machine:type_name -> machine.v1alpha1.Machine
-	59, // 33: machine.v1alpha1.UpdateMachineAnnotationsRequest.annotations:type_name -> machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
-	0,  // 34: machine.v1alpha1.UpdateMachinePowerRequest.power:type_name -> machine.v1alpha1.Power
-	12, // 35: machine.v1alpha1.AttachVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
-	12, // 36: machine.v1alpha1.UpdateVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
-	13, // 37: machine.v1alpha1.AttachNetworkInterfaceRequest.network_interface:type_name -> machine.v1alpha1.NetworkInterface
-	19, // 38: machine.v1alpha1.StatusResponse.machine_class_status:type_name -> machine.v1alpha1.MachineClassStatus
-	20, // 39: machine.v1alpha1.MachineRuntime.Version:input_type -> machine.v1alpha1.VersionRequest
-	24, // 40: machine.v1alpha1.MachineRuntime.ListEvents:input_type -> machine.v1alpha1.ListEventsRequest
-	22, // 41: machine.v1alpha1.MachineRuntime.ListMachines:input_type -> machine.v1alpha1.ListMachinesRequest
-	26, // 42: machine.v1alpha1.MachineRuntime.CreateMachine:input_type -> machine.v1alpha1.CreateMachineRequest
-	28, // 43: machine.v1alpha1.MachineRuntime.DeleteMachine:input_type -> machine.v1alpha1.DeleteMachineRequest
-	30, // 44: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:input_type -> machine.v1alpha1.UpdateMachineAnnotationsRequest
-	32, // 45: machine.v1alpha1.MachineRuntime.UpdateMachinePower:input_type -> machine.v1alpha1.UpdateMachinePowerRequest
-	34, // 46: machine.v1alpha1.MachineRuntime.AttachVolume:input_type -> machine.v1alpha1.AttachVolumeRequest
-	36, // 47: machine.v1alpha1.MachineRuntime.DetachVolume:input_type -> machine.v1alpha1.DetachVolumeRequest
-	38, // 48: machine.v1alpha1.MachineRuntime.UpdateVolume:input_type -> machine.v1alpha1.UpdateVolumeRequest
-	40, // 49: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:input_type -> machine.v1alpha1.AttachNetworkInterfaceRequest
-	42, // 50: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:input_type -> machine.v1alpha1.DetachNetworkInterfaceRequest
-	44, // 51: machine.v1alpha1.MachineRuntime.Status:input_type -> machine.v1alpha1.StatusRequest
-	46, // 52: machine.v1alpha1.MachineRuntime.Exec:input_type -> machine.v1alpha1.ExecRequest
-	21, // 53: machine.v1alpha1.MachineRuntime.Version:output_type -> machine.v1alpha1.VersionResponse
-	25, // 54: machine.v1alpha1.MachineRuntime.ListEvents:output_type -> machine.v1alpha1.ListEventsResponse
-	23, // 55: machine.v1alpha1.MachineRuntime.ListMachines:output_type -> machine.v1alpha1.ListMachinesResponse
-	27, // 56: machine.v1alpha1.MachineRuntime.CreateMachine:output_type -> machine.v1alpha1.CreateMachineResponse
-	29, // 57: machine.v1alpha1.MachineRuntime.DeleteMachine:output_type -> machine.v1alpha1.DeleteMachineResponse
-	31, // 58: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:output_type -> machine.v1alpha1.UpdateMachineAnnotationsResponse
-	33, // 59: machine.v1alpha1.MachineRuntime.UpdateMachinePower:output_type -> machine.v1alpha1.UpdateMachinePowerResponse
-	35, // 60: machine.v1alpha1.MachineRuntime.AttachVolume:output_type -> machine.v1alpha1.AttachVolumeResponse
-	37, // 61: machine.v1alpha1.MachineRuntime.DetachVolume:output_type -> machine.v1alpha1.DetachVolumeResponse
-	39, // 62: machine.v1alpha1.MachineRuntime.UpdateVolume:output_type -> machine.v1alpha1.UpdateVolumeResponse
-	41, // 63: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:output_type -> machine.v1alpha1.AttachNetworkInterfaceResponse
-	43, // 64: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:output_type -> machine.v1alpha1.DetachNetworkInterfaceResponse
-	45, // 65: machine.v1alpha1.MachineRuntime.Status:output_type -> machine.v1alpha1.StatusResponse
-	47, // 66: machine.v1alpha1.MachineRuntime.Exec:output_type -> machine.v1alpha1.ExecResponse
-	53, // [53:67] is the sub-list for method output_type
-	39, // [39:53] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	0,  // 14: machine.v1alpha1.MachineSpec.power:type_name -> machine.v1alpha1.Power
+	9,  // 15: machine.v1alpha1.MachineSpec.image:type_name -> machine.v1alpha1.ImageSpec
+	12, // 16: machine.v1alpha1.MachineSpec.volumes:type_name -> machine.v1alpha1.Volume
+	13, // 17: machine.v1alpha1.MachineSpec.network_interfaces:type_name -> machine.v1alpha1.NetworkInterface
+	3,  // 18: machine.v1alpha1.MachineStatus.state:type_name -> machine.v1alpha1.MachineState
+	16, // 19: machine.v1alpha1.MachineStatus.volumes:type_name -> machine.v1alpha1.VolumeStatus
+	17, // 20: machine.v1alpha1.MachineStatus.network_interfaces:type_name -> machine.v1alpha1.NetworkInterfaceStatus
+	1,  // 21: machine.v1alpha1.VolumeStatus.state:type_name -> machine.v1alpha1.VolumeState
+	2,  // 22: machine.v1alpha1.NetworkInterfaceStatus.state:type_name -> machine.v1alpha1.NetworkInterfaceState
+	7,  // 23: machine.v1alpha1.MachineClass.capabilities:type_name -> machine.v1alpha1.MachineClassCapabilities
+	18, // 24: machine.v1alpha1.MachineClassStatus.machine_class:type_name -> machine.v1alpha1.MachineClass
+	5,  // 25: machine.v1alpha1.ListMachinesRequest.filter:type_name -> machine.v1alpha1.MachineFilter
+	8,  // 26: machine.v1alpha1.ListMachinesResponse.machines:type_name -> machine.v1alpha1.Machine
+	6,  // 27: machine.v1alpha1.ListEventsRequest.filter:type_name -> machine.v1alpha1.EventFilter
+	59, // 28: machine.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
+	8,  // 29: machine.v1alpha1.CreateMachineRequest.machine:type_name -> machine.v1alpha1.Machine
+	8,  // 30: machine.v1alpha1.CreateMachineResponse.machine:type_name -> machine.v1alpha1.Machine
+	57, // 31: machine.v1alpha1.UpdateMachineAnnotationsRequest.annotations:type_name -> machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
+	0,  // 32: machine.v1alpha1.UpdateMachinePowerRequest.power:type_name -> machine.v1alpha1.Power
+	12, // 33: machine.v1alpha1.AttachVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
+	12, // 34: machine.v1alpha1.UpdateVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
+	13, // 35: machine.v1alpha1.AttachNetworkInterfaceRequest.network_interface:type_name -> machine.v1alpha1.NetworkInterface
+	19, // 36: machine.v1alpha1.StatusResponse.machine_class_status:type_name -> machine.v1alpha1.MachineClassStatus
+	20, // 37: machine.v1alpha1.MachineRuntime.Version:input_type -> machine.v1alpha1.VersionRequest
+	24, // 38: machine.v1alpha1.MachineRuntime.ListEvents:input_type -> machine.v1alpha1.ListEventsRequest
+	22, // 39: machine.v1alpha1.MachineRuntime.ListMachines:input_type -> machine.v1alpha1.ListMachinesRequest
+	26, // 40: machine.v1alpha1.MachineRuntime.CreateMachine:input_type -> machine.v1alpha1.CreateMachineRequest
+	28, // 41: machine.v1alpha1.MachineRuntime.DeleteMachine:input_type -> machine.v1alpha1.DeleteMachineRequest
+	30, // 42: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:input_type -> machine.v1alpha1.UpdateMachineAnnotationsRequest
+	32, // 43: machine.v1alpha1.MachineRuntime.UpdateMachinePower:input_type -> machine.v1alpha1.UpdateMachinePowerRequest
+	34, // 44: machine.v1alpha1.MachineRuntime.AttachVolume:input_type -> machine.v1alpha1.AttachVolumeRequest
+	36, // 45: machine.v1alpha1.MachineRuntime.DetachVolume:input_type -> machine.v1alpha1.DetachVolumeRequest
+	38, // 46: machine.v1alpha1.MachineRuntime.UpdateVolume:input_type -> machine.v1alpha1.UpdateVolumeRequest
+	40, // 47: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:input_type -> machine.v1alpha1.AttachNetworkInterfaceRequest
+	42, // 48: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:input_type -> machine.v1alpha1.DetachNetworkInterfaceRequest
+	44, // 49: machine.v1alpha1.MachineRuntime.Status:input_type -> machine.v1alpha1.StatusRequest
+	46, // 50: machine.v1alpha1.MachineRuntime.Exec:input_type -> machine.v1alpha1.ExecRequest
+	21, // 51: machine.v1alpha1.MachineRuntime.Version:output_type -> machine.v1alpha1.VersionResponse
+	25, // 52: machine.v1alpha1.MachineRuntime.ListEvents:output_type -> machine.v1alpha1.ListEventsResponse
+	23, // 53: machine.v1alpha1.MachineRuntime.ListMachines:output_type -> machine.v1alpha1.ListMachinesResponse
+	27, // 54: machine.v1alpha1.MachineRuntime.CreateMachine:output_type -> machine.v1alpha1.CreateMachineResponse
+	29, // 55: machine.v1alpha1.MachineRuntime.DeleteMachine:output_type -> machine.v1alpha1.DeleteMachineResponse
+	31, // 56: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:output_type -> machine.v1alpha1.UpdateMachineAnnotationsResponse
+	33, // 57: machine.v1alpha1.MachineRuntime.UpdateMachinePower:output_type -> machine.v1alpha1.UpdateMachinePowerResponse
+	35, // 58: machine.v1alpha1.MachineRuntime.AttachVolume:output_type -> machine.v1alpha1.AttachVolumeResponse
+	37, // 59: machine.v1alpha1.MachineRuntime.DetachVolume:output_type -> machine.v1alpha1.DetachVolumeResponse
+	39, // 60: machine.v1alpha1.MachineRuntime.UpdateVolume:output_type -> machine.v1alpha1.UpdateVolumeResponse
+	41, // 61: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:output_type -> machine.v1alpha1.AttachNetworkInterfaceResponse
+	43, // 62: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:output_type -> machine.v1alpha1.DetachNetworkInterfaceResponse
+	45, // 63: machine.v1alpha1.MachineRuntime.Status:output_type -> machine.v1alpha1.StatusResponse
+	47, // 64: machine.v1alpha1.MachineRuntime.Exec:output_type -> machine.v1alpha1.ExecResponse
+	51, // [51:65] is the sub-list for method output_type
+	37, // [37:51] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_machine_v1alpha1_api_proto_init() }
@@ -2832,7 +2804,7 @@ func file_machine_v1alpha1_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_machine_v1alpha1_api_proto_rawDesc), len(file_machine_v1alpha1_api_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   56,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/iri/apis/machine/v1alpha1/api.pb.go
+++ b/iri/apis/machine/v1alpha1/api.pb.go
@@ -759,6 +759,7 @@ type NetworkInterface struct {
 	Ips           []string               `protobuf:"bytes,3,rep,name=ips,proto3" json:"ips,omitempty"`
 	Attributes    map[string]string      `protobuf:"bytes,4,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Labels        map[string]string      `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	NetworkLabels map[string]string      `protobuf:"bytes,6,rep,name=network_labels,json=networkLabels,proto3" json:"network_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Labels specific to the network this interface is attached to
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -824,6 +825,13 @@ func (x *NetworkInterface) GetAttributes() map[string]string {
 func (x *NetworkInterface) GetLabels() map[string]string {
 	if x != nil {
 		return x.Labels
+	}
+	return nil
+}
+
+func (x *NetworkInterface) GetNetworkLabels() map[string]string {
+	if x != nil {
+		return x.NetworkLabels
 	}
 	return nil
 }
@@ -2513,7 +2521,7 @@ const file_machine_v1alpha1_api_proto_rawDesc = "" +
 	"empty_disk\x18\x04 \x01(\v2\x1b.machine.v1alpha1.EmptyDiskR\temptyDisk\x12B\n" +
 	"\n" +
 	"connection\x18\x05 \x01(\v2\".machine.v1alpha1.VolumeConnectionR\n" +
-	"connection\"\xed\x02\n" +
+	"connection\"\x8d\x04\n" +
 	"\x10NetworkInterface\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
@@ -2522,11 +2530,15 @@ const file_machine_v1alpha1_api_proto_rawDesc = "" +
 	"\n" +
 	"attributes\x18\x04 \x03(\v22.machine.v1alpha1.NetworkInterface.AttributesEntryR\n" +
 	"attributes\x12F\n" +
-	"\x06labels\x18\x05 \x03(\v2..machine.v1alpha1.NetworkInterface.LabelsEntryR\x06labels\x1a=\n" +
+	"\x06labels\x18\x05 \x03(\v2..machine.v1alpha1.NetworkInterface.LabelsEntryR\x06labels\x12\\\n" +
+	"\x0enetwork_labels\x18\x06 \x03(\v25.machine.v1alpha1.NetworkInterface.NetworkLabelsEntryR\rnetworkLabels\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
+	"\x12NetworkLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x02\n" +
 	"\vMachineSpec\x12-\n" +
@@ -2669,7 +2681,7 @@ func file_machine_v1alpha1_api_proto_rawDescGZIP() []byte {
 }
 
 var file_machine_v1alpha1_api_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_machine_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
+var file_machine_v1alpha1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 56)
 var file_machine_v1alpha1_api_proto_goTypes = []any{
 	(Power)(0),                               // 0: machine.v1alpha1.Power
 	(VolumeState)(0),                         // 1: machine.v1alpha1.VolumeState
@@ -2729,9 +2741,10 @@ var file_machine_v1alpha1_api_proto_goTypes = []any{
 	nil,                                      // 55: machine.v1alpha1.VolumeConnection.EncryptionDataEntry
 	nil,                                      // 56: machine.v1alpha1.NetworkInterface.AttributesEntry
 	nil,                                      // 57: machine.v1alpha1.NetworkInterface.LabelsEntry
-	nil,                                      // 58: machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
-	(*v1alpha1.ObjectMetadata)(nil),          // 59: meta.v1alpha1.ObjectMetadata
-	(*v1alpha11.Event)(nil),                  // 60: event.v1alpha1.Event
+	nil,                                      // 58: machine.v1alpha1.NetworkInterface.NetworkLabelsEntry
+	nil,                                      // 59: machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
+	(*v1alpha1.ObjectMetadata)(nil),          // 60: meta.v1alpha1.ObjectMetadata
+	(*v1alpha11.Event)(nil),                  // 61: event.v1alpha1.Event
 }
 var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	48, // 0: machine.v1alpha1.VolumeSpec.attributes:type_name -> machine.v1alpha1.VolumeSpec.AttributesEntry
@@ -2739,7 +2752,7 @@ var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	50, // 2: machine.v1alpha1.MachineFilter.label_selector:type_name -> machine.v1alpha1.MachineFilter.LabelSelectorEntry
 	51, // 3: machine.v1alpha1.EventFilter.label_selector:type_name -> machine.v1alpha1.EventFilter.LabelSelectorEntry
 	52, // 4: machine.v1alpha1.MachineClassCapabilities.resources:type_name -> machine.v1alpha1.MachineClassCapabilities.ResourcesEntry
-	59, // 5: machine.v1alpha1.Machine.metadata:type_name -> meta.v1alpha1.ObjectMetadata
+	60, // 5: machine.v1alpha1.Machine.metadata:type_name -> meta.v1alpha1.ObjectMetadata
 	14, // 6: machine.v1alpha1.Machine.spec:type_name -> machine.v1alpha1.MachineSpec
 	15, // 7: machine.v1alpha1.Machine.status:type_name -> machine.v1alpha1.MachineStatus
 	53, // 8: machine.v1alpha1.VolumeConnection.attributes:type_name -> machine.v1alpha1.VolumeConnection.AttributesEntry
@@ -2749,62 +2762,63 @@ var file_machine_v1alpha1_api_proto_depIdxs = []int32{
 	11, // 12: machine.v1alpha1.Volume.connection:type_name -> machine.v1alpha1.VolumeConnection
 	56, // 13: machine.v1alpha1.NetworkInterface.attributes:type_name -> machine.v1alpha1.NetworkInterface.AttributesEntry
 	57, // 14: machine.v1alpha1.NetworkInterface.labels:type_name -> machine.v1alpha1.NetworkInterface.LabelsEntry
-	0,  // 15: machine.v1alpha1.MachineSpec.power:type_name -> machine.v1alpha1.Power
-	9,  // 16: machine.v1alpha1.MachineSpec.image:type_name -> machine.v1alpha1.ImageSpec
-	12, // 17: machine.v1alpha1.MachineSpec.volumes:type_name -> machine.v1alpha1.Volume
-	13, // 18: machine.v1alpha1.MachineSpec.network_interfaces:type_name -> machine.v1alpha1.NetworkInterface
-	3,  // 19: machine.v1alpha1.MachineStatus.state:type_name -> machine.v1alpha1.MachineState
-	16, // 20: machine.v1alpha1.MachineStatus.volumes:type_name -> machine.v1alpha1.VolumeStatus
-	17, // 21: machine.v1alpha1.MachineStatus.network_interfaces:type_name -> machine.v1alpha1.NetworkInterfaceStatus
-	1,  // 22: machine.v1alpha1.VolumeStatus.state:type_name -> machine.v1alpha1.VolumeState
-	2,  // 23: machine.v1alpha1.NetworkInterfaceStatus.state:type_name -> machine.v1alpha1.NetworkInterfaceState
-	7,  // 24: machine.v1alpha1.MachineClass.capabilities:type_name -> machine.v1alpha1.MachineClassCapabilities
-	18, // 25: machine.v1alpha1.MachineClassStatus.machine_class:type_name -> machine.v1alpha1.MachineClass
-	5,  // 26: machine.v1alpha1.ListMachinesRequest.filter:type_name -> machine.v1alpha1.MachineFilter
-	8,  // 27: machine.v1alpha1.ListMachinesResponse.machines:type_name -> machine.v1alpha1.Machine
-	6,  // 28: machine.v1alpha1.ListEventsRequest.filter:type_name -> machine.v1alpha1.EventFilter
-	60, // 29: machine.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
-	8,  // 30: machine.v1alpha1.CreateMachineRequest.machine:type_name -> machine.v1alpha1.Machine
-	8,  // 31: machine.v1alpha1.CreateMachineResponse.machine:type_name -> machine.v1alpha1.Machine
-	58, // 32: machine.v1alpha1.UpdateMachineAnnotationsRequest.annotations:type_name -> machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
-	0,  // 33: machine.v1alpha1.UpdateMachinePowerRequest.power:type_name -> machine.v1alpha1.Power
-	12, // 34: machine.v1alpha1.AttachVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
-	12, // 35: machine.v1alpha1.UpdateVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
-	13, // 36: machine.v1alpha1.AttachNetworkInterfaceRequest.network_interface:type_name -> machine.v1alpha1.NetworkInterface
-	19, // 37: machine.v1alpha1.StatusResponse.machine_class_status:type_name -> machine.v1alpha1.MachineClassStatus
-	20, // 38: machine.v1alpha1.MachineRuntime.Version:input_type -> machine.v1alpha1.VersionRequest
-	24, // 39: machine.v1alpha1.MachineRuntime.ListEvents:input_type -> machine.v1alpha1.ListEventsRequest
-	22, // 40: machine.v1alpha1.MachineRuntime.ListMachines:input_type -> machine.v1alpha1.ListMachinesRequest
-	26, // 41: machine.v1alpha1.MachineRuntime.CreateMachine:input_type -> machine.v1alpha1.CreateMachineRequest
-	28, // 42: machine.v1alpha1.MachineRuntime.DeleteMachine:input_type -> machine.v1alpha1.DeleteMachineRequest
-	30, // 43: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:input_type -> machine.v1alpha1.UpdateMachineAnnotationsRequest
-	32, // 44: machine.v1alpha1.MachineRuntime.UpdateMachinePower:input_type -> machine.v1alpha1.UpdateMachinePowerRequest
-	34, // 45: machine.v1alpha1.MachineRuntime.AttachVolume:input_type -> machine.v1alpha1.AttachVolumeRequest
-	36, // 46: machine.v1alpha1.MachineRuntime.DetachVolume:input_type -> machine.v1alpha1.DetachVolumeRequest
-	38, // 47: machine.v1alpha1.MachineRuntime.UpdateVolume:input_type -> machine.v1alpha1.UpdateVolumeRequest
-	40, // 48: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:input_type -> machine.v1alpha1.AttachNetworkInterfaceRequest
-	42, // 49: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:input_type -> machine.v1alpha1.DetachNetworkInterfaceRequest
-	44, // 50: machine.v1alpha1.MachineRuntime.Status:input_type -> machine.v1alpha1.StatusRequest
-	46, // 51: machine.v1alpha1.MachineRuntime.Exec:input_type -> machine.v1alpha1.ExecRequest
-	21, // 52: machine.v1alpha1.MachineRuntime.Version:output_type -> machine.v1alpha1.VersionResponse
-	25, // 53: machine.v1alpha1.MachineRuntime.ListEvents:output_type -> machine.v1alpha1.ListEventsResponse
-	23, // 54: machine.v1alpha1.MachineRuntime.ListMachines:output_type -> machine.v1alpha1.ListMachinesResponse
-	27, // 55: machine.v1alpha1.MachineRuntime.CreateMachine:output_type -> machine.v1alpha1.CreateMachineResponse
-	29, // 56: machine.v1alpha1.MachineRuntime.DeleteMachine:output_type -> machine.v1alpha1.DeleteMachineResponse
-	31, // 57: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:output_type -> machine.v1alpha1.UpdateMachineAnnotationsResponse
-	33, // 58: machine.v1alpha1.MachineRuntime.UpdateMachinePower:output_type -> machine.v1alpha1.UpdateMachinePowerResponse
-	35, // 59: machine.v1alpha1.MachineRuntime.AttachVolume:output_type -> machine.v1alpha1.AttachVolumeResponse
-	37, // 60: machine.v1alpha1.MachineRuntime.DetachVolume:output_type -> machine.v1alpha1.DetachVolumeResponse
-	39, // 61: machine.v1alpha1.MachineRuntime.UpdateVolume:output_type -> machine.v1alpha1.UpdateVolumeResponse
-	41, // 62: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:output_type -> machine.v1alpha1.AttachNetworkInterfaceResponse
-	43, // 63: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:output_type -> machine.v1alpha1.DetachNetworkInterfaceResponse
-	45, // 64: machine.v1alpha1.MachineRuntime.Status:output_type -> machine.v1alpha1.StatusResponse
-	47, // 65: machine.v1alpha1.MachineRuntime.Exec:output_type -> machine.v1alpha1.ExecResponse
-	52, // [52:66] is the sub-list for method output_type
-	38, // [38:52] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	58, // 15: machine.v1alpha1.NetworkInterface.network_labels:type_name -> machine.v1alpha1.NetworkInterface.NetworkLabelsEntry
+	0,  // 16: machine.v1alpha1.MachineSpec.power:type_name -> machine.v1alpha1.Power
+	9,  // 17: machine.v1alpha1.MachineSpec.image:type_name -> machine.v1alpha1.ImageSpec
+	12, // 18: machine.v1alpha1.MachineSpec.volumes:type_name -> machine.v1alpha1.Volume
+	13, // 19: machine.v1alpha1.MachineSpec.network_interfaces:type_name -> machine.v1alpha1.NetworkInterface
+	3,  // 20: machine.v1alpha1.MachineStatus.state:type_name -> machine.v1alpha1.MachineState
+	16, // 21: machine.v1alpha1.MachineStatus.volumes:type_name -> machine.v1alpha1.VolumeStatus
+	17, // 22: machine.v1alpha1.MachineStatus.network_interfaces:type_name -> machine.v1alpha1.NetworkInterfaceStatus
+	1,  // 23: machine.v1alpha1.VolumeStatus.state:type_name -> machine.v1alpha1.VolumeState
+	2,  // 24: machine.v1alpha1.NetworkInterfaceStatus.state:type_name -> machine.v1alpha1.NetworkInterfaceState
+	7,  // 25: machine.v1alpha1.MachineClass.capabilities:type_name -> machine.v1alpha1.MachineClassCapabilities
+	18, // 26: machine.v1alpha1.MachineClassStatus.machine_class:type_name -> machine.v1alpha1.MachineClass
+	5,  // 27: machine.v1alpha1.ListMachinesRequest.filter:type_name -> machine.v1alpha1.MachineFilter
+	8,  // 28: machine.v1alpha1.ListMachinesResponse.machines:type_name -> machine.v1alpha1.Machine
+	6,  // 29: machine.v1alpha1.ListEventsRequest.filter:type_name -> machine.v1alpha1.EventFilter
+	61, // 30: machine.v1alpha1.ListEventsResponse.events:type_name -> event.v1alpha1.Event
+	8,  // 31: machine.v1alpha1.CreateMachineRequest.machine:type_name -> machine.v1alpha1.Machine
+	8,  // 32: machine.v1alpha1.CreateMachineResponse.machine:type_name -> machine.v1alpha1.Machine
+	59, // 33: machine.v1alpha1.UpdateMachineAnnotationsRequest.annotations:type_name -> machine.v1alpha1.UpdateMachineAnnotationsRequest.AnnotationsEntry
+	0,  // 34: machine.v1alpha1.UpdateMachinePowerRequest.power:type_name -> machine.v1alpha1.Power
+	12, // 35: machine.v1alpha1.AttachVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
+	12, // 36: machine.v1alpha1.UpdateVolumeRequest.volume:type_name -> machine.v1alpha1.Volume
+	13, // 37: machine.v1alpha1.AttachNetworkInterfaceRequest.network_interface:type_name -> machine.v1alpha1.NetworkInterface
+	19, // 38: machine.v1alpha1.StatusResponse.machine_class_status:type_name -> machine.v1alpha1.MachineClassStatus
+	20, // 39: machine.v1alpha1.MachineRuntime.Version:input_type -> machine.v1alpha1.VersionRequest
+	24, // 40: machine.v1alpha1.MachineRuntime.ListEvents:input_type -> machine.v1alpha1.ListEventsRequest
+	22, // 41: machine.v1alpha1.MachineRuntime.ListMachines:input_type -> machine.v1alpha1.ListMachinesRequest
+	26, // 42: machine.v1alpha1.MachineRuntime.CreateMachine:input_type -> machine.v1alpha1.CreateMachineRequest
+	28, // 43: machine.v1alpha1.MachineRuntime.DeleteMachine:input_type -> machine.v1alpha1.DeleteMachineRequest
+	30, // 44: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:input_type -> machine.v1alpha1.UpdateMachineAnnotationsRequest
+	32, // 45: machine.v1alpha1.MachineRuntime.UpdateMachinePower:input_type -> machine.v1alpha1.UpdateMachinePowerRequest
+	34, // 46: machine.v1alpha1.MachineRuntime.AttachVolume:input_type -> machine.v1alpha1.AttachVolumeRequest
+	36, // 47: machine.v1alpha1.MachineRuntime.DetachVolume:input_type -> machine.v1alpha1.DetachVolumeRequest
+	38, // 48: machine.v1alpha1.MachineRuntime.UpdateVolume:input_type -> machine.v1alpha1.UpdateVolumeRequest
+	40, // 49: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:input_type -> machine.v1alpha1.AttachNetworkInterfaceRequest
+	42, // 50: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:input_type -> machine.v1alpha1.DetachNetworkInterfaceRequest
+	44, // 51: machine.v1alpha1.MachineRuntime.Status:input_type -> machine.v1alpha1.StatusRequest
+	46, // 52: machine.v1alpha1.MachineRuntime.Exec:input_type -> machine.v1alpha1.ExecRequest
+	21, // 53: machine.v1alpha1.MachineRuntime.Version:output_type -> machine.v1alpha1.VersionResponse
+	25, // 54: machine.v1alpha1.MachineRuntime.ListEvents:output_type -> machine.v1alpha1.ListEventsResponse
+	23, // 55: machine.v1alpha1.MachineRuntime.ListMachines:output_type -> machine.v1alpha1.ListMachinesResponse
+	27, // 56: machine.v1alpha1.MachineRuntime.CreateMachine:output_type -> machine.v1alpha1.CreateMachineResponse
+	29, // 57: machine.v1alpha1.MachineRuntime.DeleteMachine:output_type -> machine.v1alpha1.DeleteMachineResponse
+	31, // 58: machine.v1alpha1.MachineRuntime.UpdateMachineAnnotations:output_type -> machine.v1alpha1.UpdateMachineAnnotationsResponse
+	33, // 59: machine.v1alpha1.MachineRuntime.UpdateMachinePower:output_type -> machine.v1alpha1.UpdateMachinePowerResponse
+	35, // 60: machine.v1alpha1.MachineRuntime.AttachVolume:output_type -> machine.v1alpha1.AttachVolumeResponse
+	37, // 61: machine.v1alpha1.MachineRuntime.DetachVolume:output_type -> machine.v1alpha1.DetachVolumeResponse
+	39, // 62: machine.v1alpha1.MachineRuntime.UpdateVolume:output_type -> machine.v1alpha1.UpdateVolumeResponse
+	41, // 63: machine.v1alpha1.MachineRuntime.AttachNetworkInterface:output_type -> machine.v1alpha1.AttachNetworkInterfaceResponse
+	43, // 64: machine.v1alpha1.MachineRuntime.DetachNetworkInterface:output_type -> machine.v1alpha1.DetachNetworkInterfaceResponse
+	45, // 65: machine.v1alpha1.MachineRuntime.Status:output_type -> machine.v1alpha1.StatusResponse
+	47, // 66: machine.v1alpha1.MachineRuntime.Exec:output_type -> machine.v1alpha1.ExecResponse
+	53, // [53:67] is the sub-list for method output_type
+	39, // [39:53] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_machine_v1alpha1_api_proto_init() }
@@ -2818,7 +2832,7 @@ func file_machine_v1alpha1_api_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_machine_v1alpha1_api_proto_rawDesc), len(file_machine_v1alpha1_api_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   55,
+			NumMessages:   56,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/iri/apis/machine/v1alpha1/api.proto
+++ b/iri/apis/machine/v1alpha1/api.proto
@@ -85,6 +85,7 @@ message NetworkInterface {
   repeated string ips = 3;
   map<string, string> attributes = 4;
   map<string, string> labels = 5;
+  map<string, string> network_labels = 6; // Labels specific to the network this interface is attached to
 }
 
 enum Power {

--- a/iri/apis/machine/v1alpha1/api.proto
+++ b/iri/apis/machine/v1alpha1/api.proto
@@ -84,8 +84,6 @@ message NetworkInterface {
   string network_id = 2;
   repeated string ips = 3;
   map<string, string> attributes = 4;
-  map<string, string> labels = 5;
-  map<string, string> network_labels = 6; // Labels specific to the network this interface is attached to
 }
 
 enum Power {

--- a/poollet/bucketpoollet/controllers/bucket_controller.go
+++ b/poollet/bucketpoollet/controllers/bucket_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ironcore-dev/ironcore/utils/predicates"
 
 	"github.com/ironcore-dev/controller-utils/clientutils"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,9 +68,7 @@ func (r *BucketReconciler) iriBucketLabels(bucket *storagev1alpha1.Bucket) (map[
 	if err != nil {
 		return nil, err
 	}
-	for k, v := range apiLabels {
-		labels[k] = v
-	}
+	labels = utilsmaps.AppendMap(labels, apiLabels)
 	return labels, nil
 }
 

--- a/poollet/bucketpoollet/controllers/bucket_controller.go
+++ b/poollet/bucketpoollet/controllers/bucket_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/kubectl/pkg/util/fieldpath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,11 +63,12 @@ func (r *BucketReconciler) iriBucketLabels(bucket *storagev1alpha1.Bucket) (map[
 		bucketpoolletv1alpha1.BucketNamespaceLabel: bucket.Namespace,
 		bucketpoolletv1alpha1.BucketNameLabel:      bucket.Name,
 	}
-	for downwardAPILabelName, fieldPath := range r.DownwardAPILabels {
-		value, err := fieldpath.ExtractFieldPathAsString(bucket, fieldPath)
-		if err == nil && value != "" {
-			labels[poolletutils.DownwardAPILabel(bucketpoolletv1alpha1.BucketDownwardAPIPrefix, downwardAPILabelName)] = value
-		}
+	apiLabels, err := poolletutils.PrepareDownwardAPILabels(bucket, r.DownwardAPILabels, bucketpoolletv1alpha1.BucketDownwardAPIPrefix)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range apiLabels {
+		labels[k] = v
 	}
 	return labels, nil
 }

--- a/poollet/machinepoollet/api/v1alpha1/common_types.go
+++ b/poollet/machinepoollet/api/v1alpha1/common_types.go
@@ -20,6 +20,10 @@ const (
 	NetworkInterfaceNamespaceLabel = "machinepoollet.ironcore.dev/nic-namespace"
 	NetworkInterfaceNameLabel      = "machinepoollet.ironcore.dev/nic-name"
 
+	NetworkUIDLabel       = "machinepoollet.ironcore.dev/network-uid"
+	NetworkNamespaceLabel = "machinepoollet.ironcore.dev/network-namespace"
+	NetworkNameLabel      = "machinepoollet.ironcore.dev/network-name"
+
 	MachineGenerationAnnotation    = "machinepoollet.ironcore.dev/machine-generation"
 	IRIMachineGenerationAnnotation = "machinepoollet.ironcore.dev/irimachine-generation"
 

--- a/poollet/machinepoollet/api/v1alpha1/common_types.go
+++ b/poollet/machinepoollet/api/v1alpha1/common_types.go
@@ -24,6 +24,9 @@ const (
 	NetworkNamespaceLabel = "machinepoollet.ironcore.dev/network-namespace"
 	NetworkNameLabel      = "machinepoollet.ironcore.dev/network-name"
 
+	NICLabelsAttributeKey     = "nicLabels"
+	NetworkLabelsAttributeKey = "networkLabels"
+
 	MachineGenerationAnnotation    = "machinepoollet.ironcore.dev/machine-generation"
 	IRIMachineGenerationAnnotation = "machinepoollet.ironcore.dev/irimachine-generation"
 

--- a/poollet/machinepoollet/api/v1alpha1/common_types.go
+++ b/poollet/machinepoollet/api/v1alpha1/common_types.go
@@ -24,8 +24,8 @@ const (
 	NetworkNamespaceLabel = "machinepoollet.ironcore.dev/network-namespace"
 	NetworkNameLabel      = "machinepoollet.ironcore.dev/network-name"
 
-	NICLabelsAttributeKey     = "nicLabels"
-	NetworkLabelsAttributeKey = "networkLabels"
+	NICLabelsAttributeKey     = "rawNICLabels"
+	NetworkLabelsAttributeKey = "rawNetworkLabels"
 
 	MachineGenerationAnnotation    = "machinepoollet.ironcore.dev/machine-generation"
 	IRIMachineGenerationAnnotation = "machinepoollet.ironcore.dev/irimachine-generation"

--- a/poollet/machinepoollet/cmd/machinepoollet/app/app.go
+++ b/poollet/machinepoollet/cmd/machinepoollet/app/app.go
@@ -77,8 +77,12 @@ type Options struct {
 	MachineDownwardAPILabels      map[string]string
 	MachineDownwardAPIAnnotations map[string]string
 
-	NicDownwardAPILabels                 map[string]string
-	NicDownwardAPIAnnotations            map[string]string
+	NicDownwardAPILabels      map[string]string
+	NicDownwardAPIAnnotations map[string]string
+
+	NetworkDownwardAPILabels      map[string]string
+	NetworkDownwardAPIAnnotations map[string]string
+
 	ProviderID                           string
 	MachineRuntimeEndpoint               string
 	MachineRuntimeSocketDiscoveryTimeout time.Duration
@@ -122,6 +126,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringToStringVar(&o.MachineDownwardAPIAnnotations, "machine-downward-api-annotation", o.MachineDownwardAPIAnnotations, "Downward-API annotations to set on the iri machine.")
 	fs.StringToStringVar(&o.NicDownwardAPILabels, "nic-downward-api-label", o.NicDownwardAPILabels, "Downward-API labels to set on the iri nic.")
 	fs.StringToStringVar(&o.NicDownwardAPIAnnotations, "nic-downward-api-annotation", o.NicDownwardAPIAnnotations, "Downward-API annotations to set on the iri nic.")
+	fs.StringToStringVar(&o.NetworkDownwardAPILabels, "network-downward-api-label", o.NetworkDownwardAPILabels, "Downward-API labels to set on the iri network.")
+	fs.StringToStringVar(&o.NetworkDownwardAPIAnnotations, "network-downward-api-annotation", o.NetworkDownwardAPIAnnotations, "Downward-API annotations to set on the iri network.")
 	fs.StringVar(&o.ProviderID, "provider-id", "", "Provider id to announce on the machine pool.")
 	fs.StringVar(&o.MachineRuntimeEndpoint, "machine-runtime-endpoint", o.MachineRuntimeEndpoint, "Endpoint of the remote machine runtime service.")
 	fs.DurationVar(&o.MachineRuntimeSocketDiscoveryTimeout, "machine-runtime-socket-discovery-timeout", 20*time.Second, "Timeout for discovering the machine runtime socket.")
@@ -423,6 +429,8 @@ func Run(ctx context.Context, opts Options) error {
 			MachineDownwardAPIAnnotations: opts.MachineDownwardAPIAnnotations,
 			NicDownwardAPILabels:          opts.NicDownwardAPILabels,
 			NicDownwardAPIAnnotations:     opts.NicDownwardAPIAnnotations,
+			NetworkDownwardAPILabels:      opts.NetworkDownwardAPILabels,
+			NetworkDownwardAPIAnnotations: opts.NetworkDownwardAPIAnnotations,
 			WatchFilterValue:              opts.WatchFilterValue,
 			MaxConcurrentReconciles:       opts.MaxConcurrentReconciles,
 		}).SetupWithManager(mgr); err != nil {

--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -240,6 +240,9 @@ func SetupTest() (*corev1.Namespace, *computev1alpha1.MachinePool, *computev1alp
 			NicDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
 			},
+			NetworkDownwardAPILabels: map[string]string{
+				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
+			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		machineEvents := irievent.NewGenerator(func(ctx context.Context) ([]*iri.Machine, error) {

--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -239,9 +239,11 @@ func SetupTest() (*corev1.Namespace, *computev1alpha1.MachinePool, *computev1alp
 			},
 			NicDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
+				"root-nic-uid":      "metadata.uid",
 			},
 			NetworkDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
+				"root-network-uid":  "metadata.uid",
 			},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -63,6 +63,9 @@ type MachineReconciler struct {
 	NicDownwardAPILabels      map[string]string
 	NicDownwardAPIAnnotations map[string]string
 
+	NetworkDownwardAPILabels      map[string]string
+	NetworkDownwardAPIAnnotations map[string]string
+
 	WatchFilterValue string
 
 	MaxConcurrentReconciles int
@@ -348,13 +351,12 @@ func (r *MachineReconciler) iriMachineLabels(machine *computev1alpha1.Machine) (
 		v1alpha1.MachineNameLabel:      machine.Name,
 	}
 
-	for name, fieldPath := range r.MachineDownwardAPILabels {
-		value, err := fieldpath.ExtractFieldPathAsString(machine, fieldPath)
-		if err != nil {
-			return nil, fmt.Errorf("error extracting downward api label %q: %w", name, err)
-		}
-
-		labels[poolletutils.DownwardAPILabel(v1alpha1.MachineDownwardAPIPrefix, name)] = value
+	apiLabels, err := poolletutils.PrepareDownwardAPILabels(machine, r.MachineDownwardAPILabels, v1alpha1.MachineDownwardAPIPrefix)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range apiLabels {
+		labels[k] = v
 	}
 	return labels, nil
 }

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/controllers/events"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/mcm"
 	utilclient "github.com/ironcore-dev/ironcore/utils/client"
-	utilmaps "github.com/ironcore-dev/ironcore/utils/maps"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
 
 	corev1 "k8s.io/api/core/v1"
@@ -355,9 +355,7 @@ func (r *MachineReconciler) iriMachineLabels(machine *computev1alpha1.Machine) (
 	if err != nil {
 		return nil, err
 	}
-	for k, v := range apiLabels {
-		labels[k] = v
-	}
+	labels = utilsmaps.AppendMap(labels, apiLabels)
 	return labels, nil
 }
 
@@ -517,7 +515,7 @@ func (r *MachineReconciler) updateNetworkInterfaceStatus(
 			continue
 		}
 
-		nic, ok := utilmaps.Pop(unhandledNicByUID, ref.UID)
+		nic, ok := utilsmaps.Pop(unhandledNicByUID, ref.UID)
 		if !ok {
 			continue
 		}

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -16,6 +16,7 @@ import (
 	testingmachine "github.com/ironcore-dev/ironcore/iri/testing/machine"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
+	"github.com/ironcore-dev/ironcore/utils/maps"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -159,11 +160,9 @@ var _ = Describe("MachineController", func() {
 			Name:      "primary",
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.11"},
-			Labels: map[string]string{
-				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
-			},
-			NetworkLabels: map[string]string{
-				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+			Attributes: map[string]string{
+				machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
 			},
 		})))
 
@@ -324,11 +323,9 @@ var _ = Describe("MachineController", func() {
 			Name:      "primary",
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.1"},
-			Labels: map[string]string{
-				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
-			},
-			NetworkLabels: map[string]string{
-				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+			Attributes: map[string]string{
+				machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
 			},
 		})))
 

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -12,11 +12,11 @@ import (
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
+	machinebrokerutils "github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	testingmachine "github.com/ironcore-dev/ironcore/iri/testing/machine"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
-	"github.com/ironcore-dev/ironcore/utils/maps"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -161,8 +161,20 @@ var _ = Describe("MachineController", func() {
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.11"},
 			Attributes: map[string]string{
-				machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
-				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
+				machinepoolletv1alpha1.NICLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"):      string(nic.UID),
+					machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
+					machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               string(nic.Namespace),
+					machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    string(nic.Name),
+				})),
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"):  string(network.UID),
+					machinepoolletv1alpha1.NetworkUIDLabel:       string(network.UID),
+					machinepoolletv1alpha1.NetworkNamespaceLabel: string(network.Namespace),
+					machinepoolletv1alpha1.NetworkNameLabel:      string(network.Name),
+				})),
 			},
 		})))
 
@@ -324,8 +336,20 @@ var _ = Describe("MachineController", func() {
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.1"},
 			Attributes: map[string]string{
-				machinepoolletv1alpha1.NICLabelsAttributeKey:     string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
-				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(maps.MustMarshalJSON(map[string]string{poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue})),
+				machinepoolletv1alpha1.NICLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"):      string(nic.UID),
+					machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
+					machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               string(nic.Namespace),
+					machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    string(nic.Name),
+				})),
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"):  string(network.UID),
+					machinepoolletv1alpha1.NetworkUIDLabel:       string(network.UID),
+					machinepoolletv1alpha1.NetworkNamespaceLabel: string(network.Namespace),
+					machinepoolletv1alpha1.NetworkNameLabel:      string(network.Name),
+				})),
 			},
 		})))
 

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -34,10 +34,14 @@ var _ = Describe("MachineController", func() {
 
 	It("Should create a machine with an ephemeral NIC and ensure claimed networkInterfaceRef matches the ephemeral NIC", func(ctx SpecContext) {
 		By("creating a network")
+		const fooAnnotationValue = "bar"
 		network := &networkingv1alpha1.Network{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
 				GenerateName: "network-",
+				Annotations: map[string]string{
+					fooAnnotation: fooAnnotationValue,
+				},
 			},
 			Spec: networkingv1alpha1.NetworkSpec{
 				ProviderID: "foo",
@@ -72,7 +76,6 @@ var _ = Describe("MachineController", func() {
 		})).Should(Succeed())
 
 		By("creating a machine")
-		const fooAnnotationValue = "bar"
 		machine := &computev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
@@ -159,6 +162,9 @@ var _ = Describe("MachineController", func() {
 			Labels: map[string]string{
 				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 			},
+			NetworkLabels: map[string]string{
+				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+			},
 		})))
 
 		By("waiting for the ironcore machine status to be up-to-date")
@@ -207,6 +213,9 @@ var _ = Describe("MachineController", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
 				GenerateName: "network-",
+				Annotations: map[string]string{
+					fooAnnotation: fooAnnotationValue,
+				},
 			},
 			Spec: networkingv1alpha1.NetworkSpec{
 				ProviderID: "foo",
@@ -316,6 +325,9 @@ var _ = Describe("MachineController", func() {
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.1"},
 			Labels: map[string]string{
+				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
+			},
+			NetworkLabels: map[string]string{
 				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 			},
 		})))

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -4,6 +4,7 @@
 package controllers_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	. "github.com/afritzler/protoequal"
@@ -12,7 +13,6 @@ import (
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
-	machinebrokerutils "github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	testingmachine "github.com/ironcore-dev/ironcore/iri/testing/machine"
 	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
@@ -161,14 +161,14 @@ var _ = Describe("MachineController", func() {
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.11"},
 			Attributes: map[string]string{
-				machinepoolletv1alpha1.NICLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+				machinepoolletv1alpha1.NICLabelsAttributeKey: string(mustMarshalJSON(map[string]string{
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"):      string(nic.UID),
 					machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
 					machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               string(nic.Namespace),
 					machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    string(nic.Name),
 				})),
-				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(mustMarshalJSON(map[string]string{
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"):  string(network.UID),
 					machinepoolletv1alpha1.NetworkUIDLabel:       string(network.UID),
@@ -336,14 +336,14 @@ var _ = Describe("MachineController", func() {
 			NetworkId: "foo",
 			Ips:       []string{"10.0.0.1"},
 			Attributes: map[string]string{
-				machinepoolletv1alpha1.NICLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+				machinepoolletv1alpha1.NICLabelsAttributeKey: string(mustMarshalJSON(map[string]string{
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-nic-uid"):      string(nic.UID),
 					machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
 					machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               string(nic.Namespace),
 					machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    string(nic.Name),
 				})),
-				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(machinebrokerutils.MustMarshalJSON(map[string]string{
+				machinepoolletv1alpha1.NetworkLabelsAttributeKey: string(mustMarshalJSON(map[string]string{
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
 					poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-network-uid"):  string(network.UID),
 					machinepoolletv1alpha1.NetworkUIDLabel:       string(network.UID),
@@ -816,4 +816,12 @@ func GetSingleMapEntry[K comparable, V any](m map[K]V) (K, V) {
 		return k, v
 	}
 	panic("unreachable")
+}
+
+func mustMarshalJSON(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/kubectl/pkg/util/fieldpath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,13 +68,12 @@ func (r *VolumeReconciler) iriVolumeLabels(volume *storagev1alpha1.Volume) (map[
 		volumepoolletv1alpha1.VolumeNamespaceLabel: volume.Namespace,
 		volumepoolletv1alpha1.VolumeNameLabel:      volume.Name,
 	}
-	for name, fieldPath := range r.DownwardAPILabels {
-		value, err := fieldpath.ExtractFieldPathAsString(volume, fieldPath)
-		if err != nil {
-			return nil, fmt.Errorf("error extracting downward api label %q: %w", name, err)
-		}
-
-		labels[poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, name)] = value
+	apiLabels, err := poolletutils.PrepareDownwardAPILabels(volume, r.DownwardAPILabels, volumepoolletv1alpha1.VolumeDownwardAPIPrefix)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range apiLabels {
+		labels[k] = v
 	}
 	return labels, nil
 }

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -22,6 +22,7 @@ import (
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/poollet/volumepoollet/controllers/events"
 	"github.com/ironcore-dev/ironcore/poollet/volumepoollet/vcm"
+	utilsmaps "github.com/ironcore-dev/ironcore/utils/maps"
 
 	ironcoreclient "github.com/ironcore-dev/ironcore/utils/client"
 	"github.com/ironcore-dev/ironcore/utils/predicates"
@@ -72,9 +73,7 @@ func (r *VolumeReconciler) iriVolumeLabels(volume *storagev1alpha1.Volume) (map[
 	if err != nil {
 		return nil, err
 	}
-	for k, v := range apiLabels {
-		labels[k] = v
-	}
+	labels = utilsmaps.AppendMap(labels, apiLabels)
 	return labels, nil
 }
 

--- a/utils/maps/maps.go
+++ b/utils/maps/maps.go
@@ -3,6 +3,11 @@
 
 package maps
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Pop gets the value associated with the key (if any) and deletes it from the map.
 func Pop[M ~map[K]V, K comparable, V any](m M, key K) (V, bool) {
 	v, ok := m[key]
@@ -20,4 +25,32 @@ func AppendMap[M ~map[K]V, K comparable, V any](m M, ms ...M) map[K]V {
 		}
 	}
 	return m
+}
+
+func Clone[M ~map[K]V, K comparable, V any](m M) M {
+	clone := make(M)
+	for k, v := range m {
+		clone[k] = v
+	}
+	return clone
+}
+
+// MustMarshalJSON is a helper function that marshals the given value to JSON and panics if an error occurs.
+func MustMarshalJSON(v interface{}) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func UnmarshalLabels(labelsString string, present bool) (map[string]string, error) {
+	if present {
+		var labels map[string]string
+		if err := json.Unmarshal([]byte(labelsString), &labels); err != nil {
+			return nil, fmt.Errorf("error unmarshaling labels: %w", err)
+		}
+		return labels, nil
+	}
+	return map[string]string{}, nil
 }

--- a/utils/maps/maps.go
+++ b/utils/maps/maps.go
@@ -3,11 +3,6 @@
 
 package maps
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 // Pop gets the value associated with the key (if any) and deletes it from the map.
 func Pop[M ~map[K]V, K comparable, V any](m M, key K) (V, bool) {
 	v, ok := m[key]
@@ -25,32 +20,4 @@ func AppendMap[M ~map[K]V, K comparable, V any](m M, ms ...M) map[K]V {
 		}
 	}
 	return m
-}
-
-func Clone[M ~map[K]V, K comparable, V any](m M) M {
-	clone := make(M)
-	for k, v := range m {
-		clone[k] = v
-	}
-	return clone
-}
-
-// MustMarshalJSON is a helper function that marshals the given value to JSON and panics if an error occurs.
-func MustMarshalJSON(v interface{}) string {
-	data, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return string(data)
-}
-
-func UnmarshalLabels(labelsString string, present bool) (map[string]string, error) {
-	if present {
-		var labels map[string]string
-		if err := json.Unmarshal([]byte(labelsString), &labels); err != nil {
-			return nil, fmt.Errorf("error unmarshaling labels: %w", err)
-		}
-		return labels, nil
-	}
-	return map[string]string{}, nil
 }


### PR DESCRIPTION
# Proposed Changes
- Remove `Labels`,  `NetworkLabels` from machine `api.proto` and reuse `Attributes` field to transport DownwardAPILabels for `Network` and `NIC` resources, This approach ensures generic behavior untouched at all layers
- Add `downward-api` labels support for `Network` resource 
- Update the `manager.yaml` with downward-api-label args
- Validate the changes with tests
- Optimize the code with reusable functions in broker and poollet 
Fix: #1316