### PR TITLE
Add the brokered downward-api NIC Labels in the machine aggregator

### DIFF
--- a/broker/machinebroker/server/machine.go
+++ b/broker/machinebroker/server/machine.go
@@ -173,6 +173,7 @@ func (s *Server) convertIronCoreNetworkInterfaceAttachment(
 			NetworkId:  ironcoreNic.Network.Spec.ProviderID,
 			Ips:        ips,
 			Attributes: ironcoreNic.NetworkInterface.Spec.Attributes,
+			Labels:     ironcoreNic.NetworkInterface.Labels,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unrecognized ironcore machine network interface %#v", ironcoreMachineNic)

--- a/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
+++ b/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
@@ -100,7 +100,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElectionKubeconfig, "leader-election-kubeconfig", "", "Path pointing to a kubeconfig to use for leader election.")
 
 	fs.StringToStringVar(&o.BucketDownwardAPILabels, "bucket-downward-api-label", o.BucketDownwardAPILabels, "Downward-API labels to set on the IRI bucket.")
-	fs.StringToStringVar(&o.BucketDownwardAPIAnnotations, "bucket-downward-api-annotations", o.BucketDownwardAPIAnnotations, "Downward-API annotations to set on the IRI bucket.")
+	fs.StringToStringVar(&o.BucketDownwardAPIAnnotations, "bucket-downward-api-annotation", o.BucketDownwardAPIAnnotations, "Downward-API annotations to set on the IRI bucket.")
 	fs.StringVar(&o.BucketPoolName, "bucket-pool-name", o.BucketPoolName, "Name of the bucket pool to announce / watch")
 	fs.StringVar(&o.ProviderID, "provider-id", "", "Provider id to announce on the bucket pool.")
 	fs.StringVar(&o.BucketRuntimeEndpoint, "bucket-runtime-endpoint", o.BucketRuntimeEndpoint, "Endpoint of the remote bucket runtime service.")

--- a/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
+++ b/poollet/machinepoollet/controllers/machine_controller_networkinterface.go
@@ -217,12 +217,8 @@ func (r *MachineReconciler) getNetworkInterfaceIPs(
 }
 
 func (r *MachineReconciler) iriNetworkInterfaceLabels(networkinterface *networkingv1alpha1.NetworkInterface) (map[string]string, error) {
-	labels := map[string]string{
-		v1alpha1.NetworkInterfaceUIDLabel:       string(networkinterface.UID),
-		v1alpha1.NetworkInterfaceNamespaceLabel: networkinterface.Namespace,
-		v1alpha1.NetworkInterfaceNameLabel:      networkinterface.Name,
-	}
 
+	labels := map[string]string{}
 	for name, fieldPath := range r.NicDownwardAPILabels {
 		value, err := fieldpath.ExtractFieldPathAsString(networkinterface, fieldPath)
 		if err != nil {

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -158,9 +158,6 @@ var _ = Describe("MachineController", func() {
 			Ips:       []string{"10.0.0.11"},
 			Labels: map[string]string{
 				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
-				machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    nicName,
-				machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               ns.Name,
-				machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
 			},
 		})))
 
@@ -320,9 +317,6 @@ var _ = Describe("MachineController", func() {
 			Ips:       []string{"10.0.0.1"},
 			Labels: map[string]string{
 				poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel): fooAnnotationValue,
-				machinepoolletv1alpha1.NetworkInterfaceNameLabel:                                                    nic.Name,
-				machinepoolletv1alpha1.NetworkInterfaceNamespaceLabel:                                               ns.Name,
-				machinepoolletv1alpha1.NetworkInterfaceUIDLabel:                                                     string(nic.UID),
 			},
 		})))
 

--- a/poollet/volumepoollet/cmd/volumepoollet/app/app.go
+++ b/poollet/volumepoollet/cmd/volumepoollet/app/app.go
@@ -101,8 +101,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElectionKubeconfig, "leader-election-kubeconfig", "", "Path pointing to a kubeconfig to use for leader election.")
 
 	fs.StringVar(&o.VolumePoolName, "volume-pool-name", o.VolumePoolName, "Name of the volume pool to announce / watch")
-	fs.StringToStringVar(&o.VolumeDownwardAPILabels, "volume-downward-api-labels", o.VolumeDownwardAPILabels, "Downward-API labels to set on IRI volume.")
-	fs.StringToStringVar(&o.VolumeDownwardAPIAnnotations, "volume-downward-api-annotations", o.VolumeDownwardAPIAnnotations, "Downward-API annotations to set on the IRI volume.")
+	fs.StringToStringVar(&o.VolumeDownwardAPILabels, "volume-downward-api-label", o.VolumeDownwardAPILabels, "Downward-API labels to set on IRI volume.")
+	fs.StringToStringVar(&o.VolumeDownwardAPIAnnotations, "volume-downward-api-annotation", o.VolumeDownwardAPIAnnotations, "Downward-API annotations to set on the IRI volume.")
 	fs.StringVar(&o.ProviderID, "provider-id", "", "Provider id to announce on the volume pool.")
 	fs.StringVar(&o.VolumeRuntimeEndpoint, "volume-runtime-endpoint", o.VolumeRuntimeEndpoint, "Endpoint of the remote volume runtime service.")
 	fs.DurationVar(&o.DialTimeout, "dial-timeout", 1*time.Second, "Timeout for dialing to the volume runtime endpoint.")


### PR DESCRIPTION
# Proposed Changes

- Add the brokered downward-api NIC Labels in the machine aggregator into the broker's `machine.go`
- Add only `downward-api` labels and remove other labels for `NetworkInterface` resource
- Keep the `downward-api` flag name consistent for `Volume` and `Bucket`, similar to `Machine`

Fixes: ref/#1316