### PR TITLE
Provide flag to enable `pprof`

### DIFF
--- a/cmd/ironcore-controller-manager/main.go
+++ b/cmd/ironcore-controller-manager/main.go
@@ -109,6 +109,7 @@ func main() {
 	var enableHTTP2 bool
 	var enableLeaderElection bool
 	var probeAddr string
+	var pprofAddr string
 	var prefixAllocationTimeout time.Duration
 	var volumeBindTimeout time.Duration
 	var virtualIPBindTimeout time.Duration
@@ -125,6 +126,7 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the Pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -252,6 +254,7 @@ func main() {
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "d0ae00be.ironcore.dev",
 	})

--- a/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
+++ b/poollet/bucketpoollet/cmd/bucketpoollet/app/app.go
@@ -61,6 +61,7 @@ type Options struct {
 	LeaderElectionNamespace  string
 	LeaderElectionKubeconfig string
 	ProbeAddr                string
+	PprofAddr                string
 
 	BucketDownwardAPILabels             map[string]string
 	BucketDownwardAPIAnnotations        map[string]string
@@ -93,6 +94,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
 	fs.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.StringVar(&o.PprofAddr, "pprof-bind-address", "", "The address the Pprof endpoint binds to.")
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -253,6 +255,7 @@ func Run(ctx context.Context, opts Options) error {
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		HealthProbeBindAddress:  opts.ProbeAddr,
+		PprofBindAddress:        opts.PprofAddr,
 		LeaderElection:          opts.EnableLeaderElection,
 		LeaderElectionID:        "dwfepysc.ironcore.dev",
 		LeaderElectionNamespace: opts.LeaderElectionNamespace,

--- a/poollet/machinepoollet/cmd/machinepoollet/app/app.go
+++ b/poollet/machinepoollet/cmd/machinepoollet/app/app.go
@@ -72,6 +72,7 @@ type Options struct {
 	LeaderElectionNamespace  string
 	LeaderElectionKubeconfig string
 	ProbeAddr                string
+	PprofAddr                string
 
 	MachinePoolName               string
 	MachineDownwardAPILabels      map[string]string
@@ -115,6 +116,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
 	fs.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.StringVar(&o.PprofAddr, "pprof-bind-address", "", "The address the Pprof endpoint binds to.")
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -317,6 +319,7 @@ func Run(ctx context.Context, opts Options) error {
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		HealthProbeBindAddress:  opts.ProbeAddr,
+		PprofBindAddress:        opts.PprofAddr,
 		LeaderElection:          opts.EnableLeaderElection,
 		LeaderElectionID:        "bfafcebe.ironcore.dev",
 		LeaderElectionNamespace: opts.LeaderElectionNamespace,

--- a/poollet/volumepoollet/cmd/volumepoollet/app/app.go
+++ b/poollet/volumepoollet/cmd/volumepoollet/app/app.go
@@ -62,6 +62,7 @@ type Options struct {
 	LeaderElectionNamespace  string
 	LeaderElectionKubeconfig string
 	ProbeAddr                string
+	PprofAddr                string
 
 	VolumePoolName                      string
 	VolumeDownwardAPILabels             map[string]string
@@ -94,6 +95,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.EnableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics server")
 	fs.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.StringVar(&o.PprofAddr, "pprof-bind-address", "", "The address the Pprof endpoint binds to.")
 	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -253,6 +255,7 @@ func Run(ctx context.Context, opts Options) error {
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		HealthProbeBindAddress:  opts.ProbeAddr,
+		PprofBindAddress:        opts.PprofAddr,
 		LeaderElection:          opts.EnableLeaderElection,
 		LeaderElectionID:        "dfffbeaa.ironcore.dev",
 		LeaderElectionNamespace: opts.LeaderElectionNamespace,


### PR DESCRIPTION
# Proposed Changes

- Provide option to enable Pprof server for Ironcore controllers.
  (**_Note_**: By default option is disabled)


Fixes #1357 