### PR TITLE
Remove `downward-api` label filtering dependency

### DIFF
--- a/broker/machinebroker/server/machine_annotations_update.go
+++ b/broker/machinebroker/server/machine_annotations_update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,6 +27,14 @@ func (s *Server) UpdateMachineAnnotations(ctx context.Context, req *iri.UpdateMa
 	if err := apiutils.SetAnnotationsAnnotation(aggIronCoreMachine.Machine, req.Annotations); err != nil {
 		return nil, err
 	}
+
+	//TODO: Remove this fix once migration is done
+	log.V(1).Info("Adding ironcore machine uid label")
+	labels := aggIronCoreMachine.Machine.GetLabels()
+	if _, ok := labels[machinepoolletv1alpha1.MachineUIDLabel]; !ok {
+		labels[machinepoolletv1alpha1.MachineUIDLabel] = req.Annotations[machinepoolletv1alpha1.MachineUIDLabel]
+	}
+	aggIronCoreMachine.Machine.Labels = labels
 
 	log.V(1).Info("Patching ironcore machine annotations")
 	if err := s.cluster.Client().Patch(ctx, aggIronCoreMachine.Machine, client.MergeFrom(base)); err != nil {

--- a/broker/machinebroker/server/machine_annotations_update.go
+++ b/broker/machinebroker/server/machine_annotations_update.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ironcore-dev/ironcore/broker/machinebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
-	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,14 +26,6 @@ func (s *Server) UpdateMachineAnnotations(ctx context.Context, req *iri.UpdateMa
 	if err := apiutils.SetAnnotationsAnnotation(aggIronCoreMachine.Machine, req.Annotations); err != nil {
 		return nil, err
 	}
-
-	//TODO: Remove this fix once migration is done
-	log.V(1).Info("Adding ironcore machine uid label")
-	labels := aggIronCoreMachine.Machine.GetLabels()
-	if _, ok := labels[machinepoolletv1alpha1.MachineUIDLabel]; !ok {
-		labels[machinepoolletv1alpha1.MachineUIDLabel] = req.Annotations[machinepoolletv1alpha1.MachineUIDLabel]
-	}
-	aggIronCoreMachine.Machine.Labels = labels
 
 	log.V(1).Info("Patching ironcore machine annotations")
 	if err := s.cluster.Client().Patch(ctx, aggIronCoreMachine.Machine, client.MergeFrom(base)); err != nil {

--- a/broker/machinebroker/server/machine_create.go
+++ b/broker/machinebroker/server/machine_create.go
@@ -105,6 +105,7 @@ func (s *Server) getIronCoreMachineConfig(machine *iri.Machine) (*IronCoreMachin
 		s.brokerDownwardAPILabels,
 		machinepoolletv1alpha1.MachineDownwardAPIPrefix,
 	)
+	labels[machinepoolletv1alpha1.MachineUIDLabel] = machine.GetMetadata().GetLabels()[machinepoolletv1alpha1.MachineUIDLabel]
 	annotations, err := s.prepareIronCoreMachineAnnotations(machine)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing ironcore machine annotations: %w", err)

--- a/broker/machinebroker/server/machine_create_test.go
+++ b/broker/machinebroker/server/machine_create_test.go
@@ -49,8 +49,9 @@ var _ = Describe("CreateMachine", func() {
 		By("inspecting the ironcore machine")
 		Expect(ironcoreMachine.Labels).To(Equal(map[string]string{
 			poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, "root-machine-uid"): "foobar",
-			machinebrokerv1alpha1.CreatedLabel: "true",
-			machinebrokerv1alpha1.ManagerLabel: machinebrokerv1alpha1.MachineBrokerManager,
+			machinebrokerv1alpha1.CreatedLabel:     "true",
+			machinebrokerv1alpha1.ManagerLabel:     machinebrokerv1alpha1.MachineBrokerManager,
+			machinepoolletv1alpha1.MachineUIDLabel: "foobar",
 		}))
 		encodedIRIAnnotations, err := apiutils.EncodeAnnotationsAnnotation(nil)
 		Expect(err).NotTo(HaveOccurred())

--- a/poollet/machinepoollet/api/v1alpha1/common_types.go
+++ b/poollet/machinepoollet/api/v1alpha1/common_types.go
@@ -11,10 +11,9 @@ import (
 )
 
 const (
-	MachineUIDLabel           = "machinepoollet.ironcore.dev/machine-uid"
-	MachineNamespaceLabel     = "machinepoollet.ironcore.dev/machine-namespace"
-	MachineNameLabel          = "machinepoollet.ironcore.dev/machine-name"
-	RootMachineUIDLabelSuffix = "root-machine-uid"
+	MachineUIDLabel       = "machinepoollet.ironcore.dev/machine-uid"
+	MachineNamespaceLabel = "machinepoollet.ironcore.dev/machine-namespace"
+	MachineNameLabel      = "machinepoollet.ironcore.dev/machine-name"
 
 	NetworkInterfaceUIDLabel       = "machinepoollet.ironcore.dev/nic-uid"
 	NetworkInterfaceNamespaceLabel = "machinepoollet.ironcore.dev/nic-namespace"

--- a/poollet/machinepoollet/controllers/controllers_suite_test.go
+++ b/poollet/machinepoollet/controllers/controllers_suite_test.go
@@ -21,7 +21,6 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	"github.com/ironcore-dev/ironcore/iri/testing/machine"
 	"github.com/ironcore-dev/ironcore/poollet/irievent"
-	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	machinepoolletclient "github.com/ironcore-dev/ironcore/poollet/machinepoollet/client"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/controllers"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/mcm"
@@ -234,8 +233,7 @@ func SetupTest() (*corev1.Namespace, *computev1alpha1.MachinePool, *computev1alp
 			MachineClassMapper:    machineClassMapper,
 			MachinePoolName:       mp.Name,
 			MachineDownwardAPILabels: map[string]string{
-				fooDownwardAPILabel:                fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
-				v1alpha1.RootMachineUIDLabelSuffix: "metadata.uid",
+				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
 			},
 			NicDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubectl/pkg/util/fieldpath"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,19 +71,6 @@ type MachineReconciler struct {
 	MaxConcurrentReconciles int
 }
 
-func (r *MachineReconciler) machineKeyLabelSelector(machineKey client.ObjectKey) map[string]string {
-	return map[string]string{
-		poolletutils.DownwardAPILabel(v1alpha1.MachineDownwardAPIPrefix, "root-machine-namespace"): machineKey.Namespace,
-		poolletutils.DownwardAPILabel(v1alpha1.MachineDownwardAPIPrefix, "root-machine-name"):      machineKey.Name,
-	}
-}
-
-func (r *MachineReconciler) machineUIDLabelSelector(machineUID types.UID) map[string]string {
-	return map[string]string{
-		v1alpha1.MachineUIDLabel: string(machineUID),
-	}
-}
-
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machines,verbs=get;list;watch;update;patch
@@ -103,29 +89,26 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("error getting machine %s: %w", req.NamespacedName, err)
 		}
-		return r.deleteGone(ctx, log, req.NamespacedName)
+		return r.deleteGone(ctx, log, machine)
 	}
 	return r.reconcileExists(ctx, log, machine)
 }
 
 func (r *MachineReconciler) getIRIMachinesForMachine(ctx context.Context, machine *computev1alpha1.Machine) ([]*iri.Machine, error) {
-	res, err := r.MachineRuntime.ListMachines(ctx, &iri.ListMachinesRequest{
-		Filter: &iri.MachineFilter{LabelSelector: r.machineUIDLabelSelector(machine.GetUID())},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error listing machines by machine uid: %w", err)
+	if machine.Status.MachineID != "" {
+		machineID, err := poolletutils.ParseID(machine.Status.MachineID)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing machineID: %w", err)
+		}
+		res, err := r.MachineRuntime.ListMachines(ctx, &iri.ListMachinesRequest{
+			Filter: &iri.MachineFilter{Id: machineID.ID},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error listing machines filtering by id: %w", err)
+		}
+		return res.Machines, nil
 	}
-	return res.Machines, nil
-}
-
-func (r *MachineReconciler) listMachinesByMachineKey(ctx context.Context, machineKey client.ObjectKey) ([]*iri.Machine, error) {
-	res, err := r.MachineRuntime.ListMachines(ctx, &iri.ListMachinesRequest{
-		Filter: &iri.MachineFilter{LabelSelector: r.machineKeyLabelSelector(machineKey)},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error listing machines by machine key: %w", err)
-	}
-	return res.Machines, nil
+	return []*iri.Machine{}, nil
 }
 
 func (r *MachineReconciler) getMachineByID(ctx context.Context, id string) (*iri.Machine, error) {
@@ -181,11 +164,11 @@ func (r *MachineReconciler) deleteMachines(ctx context.Context, log logr.Logger,
 	}
 }
 
-func (r *MachineReconciler) deleteGone(ctx context.Context, log logr.Logger, machineKey client.ObjectKey) (ctrl.Result, error) {
+func (r *MachineReconciler) deleteGone(ctx context.Context, log logr.Logger, machine *computev1alpha1.Machine) (ctrl.Result, error) {
 	log.V(1).Info("Delete gone")
 
-	log.V(1).Info("Listing machines by machine key")
-	machines, err := r.listMachinesByMachineKey(ctx, machineKey)
+	log.V(1).Info("Listing IRI machines by machine")
+	machines, err := r.getIRIMachinesForMachine(ctx, machine)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error listing machines: %w", err)
 	}
@@ -219,68 +202,22 @@ func (r *MachineReconciler) delete(ctx context.Context, log logr.Logger, machine
 
 	log.V(1).Info("Finalizer present")
 
-	log.V(1).Info("Deleting machines by UID")
-	ok, err := r.deleteMachinesByMachineUID(ctx, log, machine.GetUID())
+	log.V(1).Info("Deleting IRI machine for machine")
+	res, err := r.deleteGone(ctx, log, machine)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error deleting machines: %w", err)
 	}
-	if !ok {
+	if !res.IsZero() {
 		log.V(1).Info("Not all machines are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return res, nil
 	}
-
-	log.V(1).Info("Deleted iri machines by UID, removing finalizer")
+	log.V(1).Info("Deleted iri machines for machine, removing finalizer")
 	if err := clientutils.PatchRemoveFinalizer(ctx, r.Client, machine, v1alpha1.MachineFinalizer); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error removing finalizer: %w", err)
 	}
 
 	log.V(1).Info("Deleted")
 	return ctrl.Result{}, nil
-}
-
-func (r *MachineReconciler) deleteMachinesByMachineUID(ctx context.Context, log logr.Logger, machineUID types.UID) (bool, error) {
-	log.V(1).Info("Listing machines")
-	res, err := r.MachineRuntime.ListMachines(ctx, &iri.ListMachinesRequest{
-		Filter: &iri.MachineFilter{LabelSelector: r.machineUIDLabelSelector(machineUID)},
-	})
-	if err != nil {
-		return false, fmt.Errorf("error listing machines: %w", err)
-	}
-
-	log.V(1).Info("Listed machines", "NoOfMachines", len(res.Machines))
-	var (
-		errs               []error
-		deletingMachineIDs []string
-	)
-	for _, machine := range res.Machines {
-		machineID := machine.Metadata.Id
-		log := log.WithValues("MachineID", machineID)
-		log.V(1).Info("Deleting machine")
-		_, err := r.MachineRuntime.DeleteMachine(ctx, &iri.DeleteMachineRequest{
-			MachineId: machineID,
-		})
-		if err != nil {
-			if status.Code(err) != codes.NotFound {
-				errs = append(errs, fmt.Errorf("error deleting machine %s: %w", machineID, err))
-			} else {
-				log.V(1).Info("Machine is already gone")
-			}
-		} else {
-			log.V(1).Info("Issued machine deletion")
-			deletingMachineIDs = append(deletingMachineIDs, machineID)
-		}
-	}
-
-	switch {
-	case len(errs) > 0:
-		return false, fmt.Errorf("error(s) deleting machine(s): %v", errs)
-	case len(deletingMachineIDs) > 0:
-		log.V(1).Info("Machines are in deletion", "DeletingMachineIDs", deletingMachineIDs)
-		return false, nil
-	default:
-		log.V(1).Info("All machines are gone")
-		return true, nil
-	}
 }
 
 func (r *MachineReconciler) reconcile(ctx context.Context, log logr.Logger, machine *computev1alpha1.Machine) (ctrl.Result, error) {

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -109,20 +109,6 @@ func (r *MachineReconciler) getIRIMachinesForMachine(ctx context.Context, machin
 		return nil, fmt.Errorf("error listing machines by machine uid label filter: %w", err)
 	}
 
-	//TODO: Remove this fix once migration is done
-	if len(res.Machines) == 0 && machine.Status.MachineID != "" {
-		machineID, err := poolletutils.ParseID(machine.Status.MachineID)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing machineID: %w", err)
-		}
-		res, err := r.MachineRuntime.ListMachines(ctx, &iri.ListMachinesRequest{
-			Filter: &iri.MachineFilter{Id: machineID.ID},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error listing machines by machine id: %w", err)
-		}
-		return res.Machines, nil
-	}
 	return res.Machines, nil
 }
 

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -814,7 +814,7 @@ func (r *MachineReconciler) prepareIRIMachine(
 		errs = append(errs, fmt.Errorf("error preparing iri machine labels: %w", err))
 	}
 
-	annotations, err := r.iriMachineAnnotations(machine, 1, machineNicMappings)
+	annotations, err := r.iriMachineAnnotations(machine, 0, machineNicMappings)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("error preparing iri machine annotations: %w", err))
 	}

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("MachineController", func() {
 
 		By("inspecting the iri machine")
 		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel), fooAnnotationValue))
-		// Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(machinepoolletv1alpha1.ParentMachineUIDLabel, string(machine.UID)))
+		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(machinepoolletv1alpha1.MachineUIDLabel, string(machine.UID)))
 		Expect(iriMachine.Spec.Class).To(Equal(mc.Name))
 		Expect(iriMachine.Spec.Power).To(Equal(iri.Power_POWER_ON))
 		Expect(iriMachine.Spec.Volumes).To(ConsistOf(ProtoEqual(&iri.Volume{

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("MachineController", func() {
 
 		By("inspecting the iri machine")
 		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel), fooAnnotationValue))
-		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, machinepoolletv1alpha1.RootMachineUIDLabelSuffix), string(machine.UID)))
+		// Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(machinepoolletv1alpha1.ParentMachineUIDLabel, string(machine.UID)))
 		Expect(iriMachine.Spec.Class).To(Equal(mc.Name))
 		Expect(iriMachine.Spec.Power).To(Equal(iri.Power_POWER_ON))
 		Expect(iriMachine.Spec.Volumes).To(ConsistOf(ProtoEqual(&iri.Volume{
@@ -320,7 +320,7 @@ var _ = Describe("MachineController", func() {
 
 		By("inspecting the iri machine")
 		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, fooDownwardAPILabel), fooAnnotationValue))
-		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(poolletutils.DownwardAPILabel(machinepoolletv1alpha1.MachineDownwardAPIPrefix, machinepoolletv1alpha1.RootMachineUIDLabelSuffix), string(machine.UID)))
+		Expect(iriMachine.Metadata.Labels).To(HaveKeyWithValue(machinepoolletv1alpha1.MachineUIDLabel, string(machine.UID)))
 		Expect(iriMachine.Spec.Class).To(Equal(mc.Name))
 		Expect(iriMachine.Spec.Power).To(Equal(iri.Power_POWER_ON))
 		Expect(iriMachine.Spec.Volumes).To(ConsistOf(ProtoEqual(&iri.Volume{

--- a/poollet/machinepoollet/mem/mem_test.go
+++ b/poollet/machinepoollet/mem/mem_test.go
@@ -14,7 +14,6 @@ import (
 	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
 	"github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	fakemachine "github.com/ironcore-dev/ironcore/iri/testing/machine"
-	machinepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/machinepoollet/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/controllers"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/mcm"
 	"github.com/ironcore-dev/ironcore/poollet/machinepoollet/mem"
@@ -83,7 +82,6 @@ var _ = Describe("MachineEventMapper", func() {
 			MachinePoolName:       mp.Name,
 			MachineDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),
-				machinepoolletv1alpha1.RootMachineUIDLabelSuffix: "metadata.uid",
 			},
 			NicDownwardAPILabels: map[string]string{
 				fooDownwardAPILabel: fmt.Sprintf("metadata.annotations['%s']", fooAnnotation),


### PR DESCRIPTION
# Proposed Changes

- Modify `machinepoollet` to list and delete machines using `machinepoollet.ironcore.dev/machine-uid` label
- Simplify `ListMachines` by handling it unified
- Modify `machinebroker` to add `machinepoollet.ironcore.dev/machine-uid` label with parent machine uid as value in `CreateMachine` function
- Update tests 
- Change default iriGeneration from `1` to `0`

Fixes #1339 