### PR TITLE
Switch `NameIsDNS` validation to `NameIsSubdomain` validation

### DIFF
--- a/internal/apis/compute/validation/machine.go
+++ b/internal/apis/compute/validation/machine.go
@@ -74,7 +74,7 @@ func validateMachineSpec(machineSpec *compute.MachineSpec, fldPath *field.Path) 
 		allErrs = append(allErrs, field.Required(fldPath.Child("machineClassRef"), "must specify a machine class ref"))
 	}
 
-	for _, msg := range apivalidation.NameIsDNSLabel(machineSpec.MachineClassRef.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(machineSpec.MachineClassRef.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("machineClassRef").Child("name"), machineSpec.MachineClassRef.Name, msg))
 	}
 
@@ -87,13 +87,13 @@ func validateMachineSpec(machineSpec *compute.MachineSpec, fldPath *field.Path) 
 	allErrs = append(allErrs, validateMachinePower(machineSpec.Power, fldPath.Child("power"))...)
 
 	if machineSpec.IgnitionRef != nil && machineSpec.IgnitionRef.Name != "" {
-		for _, msg := range apivalidation.NameIsDNSLabel(machineSpec.IgnitionRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(machineSpec.IgnitionRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("ignitionRef").Child("name"), machineSpec.IgnitionRef.Name, msg))
 		}
 	}
 
 	if machineSpec.ImagePullSecretRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(machineSpec.ImagePullSecretRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(machineSpec.ImagePullSecretRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), machineSpec.ImagePullSecretRef.Name, msg))
 		}
 	}

--- a/internal/apis/compute/validation/machineclass.go
+++ b/internal/apis/compute/validation/machineclass.go
@@ -15,7 +15,7 @@ import (
 func ValidateMachineClass(machineClass *compute.MachineClass) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(machineClass, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(machineClass, false, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 
 	allErrs = append(allErrs, validateMachineClassCapabilities(machineClass.Capabilities, field.NewPath("capabilities"))...)
 

--- a/internal/apis/core/validation/resourcequota.go
+++ b/internal/apis/core/validation/resourcequota.go
@@ -14,7 +14,7 @@ import (
 func ValidateResourceQuota(resourceQuota *core.ResourceQuota) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(resourceQuota, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(resourceQuota, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateResourceQuotaSpec(&resourceQuota.Spec, field.NewPath("spec"))...)
 
 	return allErrs

--- a/internal/apis/ipam/validation/prefix.go
+++ b/internal/apis/ipam/validation/prefix.go
@@ -21,7 +21,7 @@ import (
 func ValidatePrefix(prefix *ipam.Prefix) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(prefix, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(prefix, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidatePrefixSpec(&prefix.Spec, field.NewPath("spec"))...)
 
 	return allErrs

--- a/internal/apis/networking/validation/common.go
+++ b/internal/apis/networking/validation/common.go
@@ -62,7 +62,7 @@ func validatePrefixSource(src networking.PrefixSource, idx int, objectMeta *meta
 			allErrs = append(allErrs, ValidatePrefixPrefixTemplate(ephemeral.PrefixTemplate, fldPath.Child("ephemeral"))...)
 			if objectMeta != nil && objectMeta.Name != "" {
 				prefixName := networking.NetworkInterfacePrefixIPAMPrefixName(objectMeta.Name, idx)
-				for _, msg := range apivalidation.NameIsDNSLabel(prefixName, false) {
+				for _, msg := range apivalidation.NameIsDNSSubdomain(prefixName, false) {
 					allErrs = append(allErrs, field.Invalid(fldPath, prefixName, fmt.Sprintf("resulting prefix name %q is invalid: %s", prefixName, msg)))
 				}
 			}

--- a/internal/apis/networking/validation/loadbalancer.go
+++ b/internal/apis/networking/validation/loadbalancer.go
@@ -36,7 +36,7 @@ func validateLoadBalancerSpec(spec *networking.LoadBalancerSpec, lbMeta *metav1.
 
 	allErrs = append(allErrs, validateNetworkInterfaceIPSources(spec.IPs, spec.IPFamilies, lbMeta, fldPath.Child("ips"))...)
 
-	for _, msg := range apivalidation.NameIsDNSLabel(spec.NetworkRef.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(spec.NetworkRef.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef").Child("name"), spec.NetworkRef.Name, msg))
 	}
 

--- a/internal/apis/networking/validation/loadbalancerrouting.go
+++ b/internal/apis/networking/validation/loadbalancerrouting.go
@@ -14,7 +14,7 @@ import (
 func ValidateLoadBalancerRouting(loadBalancerRouting *networking.LoadBalancerRouting) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(loadBalancerRouting, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(loadBalancerRouting, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateLoadBalancerRouting(loadBalancerRouting)...)
 
 	return allErrs
@@ -31,7 +31,7 @@ func validateLoadBalancerRouting(loadBalancerRouting *networking.LoadBalancerRou
 		allErrs = append(allErrs, commonvalidation.ValidateIP(destination.IP.Family(), destination.IP, fldPath.Child("ip"))...)
 
 		if targetRef := destination.TargetRef; targetRef != nil {
-			for _, msg := range apivalidation.NameIsDNSLabel(targetRef.Name, false) {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(targetRef.Name, false) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("targetRef", "name"), targetRef.Name, msg))
 			}
 		}

--- a/internal/apis/networking/validation/natgateway.go
+++ b/internal/apis/networking/validation/natgateway.go
@@ -28,7 +28,7 @@ func validateNATGatewaySpec(spec *networking.NATGatewaySpec, fldPath *field.Path
 
 	allErrs = append(allErrs, ironcorevalidation.ValidateIPFamily(spec.IPFamily, fldPath.Child("ipFamily"))...)
 
-	for _, msg := range apivalidation.NameIsDNSLabel(spec.NetworkRef.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(spec.NetworkRef.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef").Child("name"), spec.NetworkRef.Name, msg))
 	}
 

--- a/internal/apis/networking/validation/network.go
+++ b/internal/apis/networking/validation/network.go
@@ -17,7 +17,7 @@ import (
 func ValidateNetwork(network *networking.Network) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(network, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(network, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateNetworkSpec(network.Namespace, network.Name, &network.Spec, field.NewPath("spec"))...)
 
 	return allErrs
@@ -113,7 +113,7 @@ func validateNetworkSpec(namespace, name string, spec *networking.NetworkSpec, f
 func validateNetworkPeering(peering networking.NetworkPeering, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for _, msg := range apivalidation.NameIsDNSLabel(peering.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(peering.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), peering.Name, msg))
 	}
 
@@ -123,7 +123,7 @@ func validateNetworkPeering(peering networking.NetworkPeering, fldPath *field.Pa
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef", "namespace"), networkRef.Namespace, msg))
 		}
 	}
-	for _, msg := range apivalidation.NameIsDNSLabel(networkRef.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(networkRef.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef", "name"), networkRef.Name, msg))
 	}
 
@@ -136,13 +136,13 @@ func validatePeeringClaimRef(peeringClaimRef networking.NetworkPeeringClaimRef, 
 	if len(peeringClaimRef.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "name is required"))
 	} else {
-		for _, msg := range apivalidation.NameIsDNSLabel(peeringClaimRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(peeringClaimRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), peeringClaimRef.Name, msg))
 		}
 	}
 
 	if peeringClaimRef.Namespace != "" {
-		for _, msg := range apivalidation.NameIsDNSLabel(peeringClaimRef.Namespace, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(peeringClaimRef.Namespace, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), peeringClaimRef.Namespace, msg))
 		}
 	}

--- a/internal/apis/networking/validation/networkinterface.go
+++ b/internal/apis/networking/validation/networkinterface.go
@@ -44,7 +44,7 @@ func ValidateNetworkInterfaceSpec(spec *networking.NetworkInterfaceSpec, nicMeta
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkRef"), "must specify a network ref"))
 	}
 
-	for _, msg := range apivalidation.NameIsDNSLabel(spec.NetworkRef.Name, false) {
+	for _, msg := range apivalidation.NameIsDNSSubdomain(spec.NetworkRef.Name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef").Child("name"), spec.NetworkRef.Name, msg))
 	}
 

--- a/internal/apis/networking/validation/networkpolicy.go
+++ b/internal/apis/networking/validation/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 func ValidateNetworkPolicy(networkPolicy *networking.NetworkPolicy) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(networkPolicy, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(networkPolicy, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateNetworkPolicySpec(&networkPolicy.Spec, field.NewPath("spec"))...)
 
 	return allErrs
@@ -33,7 +33,7 @@ func validateNetworkPolicySpec(spec *networking.NetworkPolicySpec, fldPath *fiel
 	if spec.NetworkRef == (corev1.LocalObjectReference{}) {
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkRef"), "must specify a network ref"))
 	} else {
-		for _, msg := range apivalidation.NameIsDNSLabel(spec.NetworkRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(spec.NetworkRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("networkRef").Child("name"), spec.NetworkRef.Name, msg))
 		}
 	}

--- a/internal/apis/networking/validation/virtualip.go
+++ b/internal/apis/networking/validation/virtualip.go
@@ -47,7 +47,7 @@ func validateVirtualIPSpec(spec *networking.VirtualIPSpec, fldPath *field.Path) 
 	allErrs = append(allErrs, ironcorevalidation.ValidateIPFamily(spec.IPFamily, fldPath.Child("ipFamily"))...)
 
 	if targetRef := spec.TargetRef; targetRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(targetRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(targetRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("targetRef", "name"), targetRef.Name, msg))
 		}
 	}

--- a/internal/apis/storage/validation/volume.go
+++ b/internal/apis/storage/validation/volume.go
@@ -29,7 +29,7 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 	var allErrs field.ErrorList
 
 	if volumeClassRef := spec.VolumeClassRef; volumeClassRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumeClassRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(spec.VolumeClassRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeClassRef").Child("name"), spec.VolumeClassRef.Name, msg))
 		}
 
@@ -49,7 +49,7 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 		}
 
 		if spec.ImagePullSecretRef != nil {
-			for _, msg := range apivalidation.NameIsDNSLabel(spec.ImagePullSecretRef.Name, false) {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(spec.ImagePullSecretRef.Name, false) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), spec.ImagePullSecretRef.Name, msg))
 			}
 		}
@@ -89,14 +89,14 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 		}
 	} else {
 		if spec.ClaimRef != nil {
-			for _, msg := range apivalidation.NameIsDNSLabel(spec.ClaimRef.Name, false) {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(spec.ClaimRef.Name, false) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("claimRef").Child("name"), spec.ClaimRef.Name, msg))
 			}
 		}
 	}
 
 	if spec.Encryption != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(spec.Encryption.SecretRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(spec.Encryption.SecretRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("encryption").Child("secretRef").Child("name"), spec.Encryption.SecretRef.Name, msg))
 		}
 	}

--- a/internal/apis/storage/validation/volumeclass.go
+++ b/internal/apis/storage/validation/volumeclass.go
@@ -15,7 +15,7 @@ import (
 func ValidateVolumeClass(volumeClass *storage.VolumeClass) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(volumeClass, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaAccessor(volumeClass, false, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
 
 	allErrs = append(allErrs, validateVolumeClassCapabilities(volumeClass.Capabilities, field.NewPath("capabilities"))...)
 

--- a/internal/apis/storage/validation/volumesnapshot.go
+++ b/internal/apis/storage/validation/volumesnapshot.go
@@ -23,7 +23,7 @@ func validateVolumeSnapshotSpec(spec *storage.VolumeSnapshotSpec, fldPath *field
 	var allErrs field.ErrorList
 
 	if spec.VolumeRef != nil {
-		for _, msg := range apivalidation.NameIsDNSLabel(spec.VolumeRef.Name, false) {
+		for _, msg := range apivalidation.NameIsDNSSubdomain(spec.VolumeRef.Name, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeRef").Child("name"), spec.VolumeRef.Name, msg))
 		}
 	}


### PR DESCRIPTION
# Proposed Changes

Switch `NameIsDNS` validation to `NameIsSubdomain` validation for `compute`, `storage` and `networking` resources.
