### PR TITLE
Modify `volumebroker` to filter volumes before aggregation

### DIFF
--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -141,7 +141,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("error serving: %w", err)
 	}
 
-	if err := srv.SetVolumeUIDLabelToAllVolumes(ctx); err != nil {
+	if err := srv.SetVolumeUIDLabelToAllVolumes(ctx, log); err != nil {
 		return fmt.Errorf("failed to set volume uid label to all brokered volumes: %w", err)
 	}
 	return nil

--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -140,5 +140,9 @@ func Run(ctx context.Context, opts Options) error {
 	if err := grpcSrv.Serve(l); err != nil {
 		return fmt.Errorf("error serving: %w", err)
 	}
+
+	if err := srv.SetVolumeUIDLabelToAllVolumes(ctx); err != nil {
+		return fmt.Errorf("failed to set volume uid label to all brokered volumes: %w", err)
+	}
 	return nil
 }

--- a/broker/volumebroker/server/event_list.go
+++ b/broker/volumebroker/server/event_list.go
@@ -40,8 +40,8 @@ func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 
 	var iriEvents []*irievent.Event
 	for _, volumeEvent := range volumeEventList.Items {
-		ironcoreVolume, err := s.getIronCoreVolume(ctx, volumeEvent.InvolvedObject.Name)
-		if err != nil {
+		ironcoreVolume := &storagev1alpha1.Volume{}
+		if err := s.getManagedAndCreated(ctx, volumeEvent.InvolvedObject.Name, ironcoreVolume); err != nil {
 			log.V(1).Info("Unable to get ironcore volume", "VolumeName", volumeEvent.InvolvedObject.Name)
 			continue
 		}

--- a/broker/volumebroker/server/volume_create.go
+++ b/broker/volumebroker/server/volume_create.go
@@ -65,6 +65,7 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 		s.brokerDownwardAPILabels,
 		volumepoolletv1alpha1.VolumeDownwardAPIPrefix,
 	)
+	labels[volumepoolletv1alpha1.VolumeUIDLabel] = volume.GetMetadata().GetLabels()[volumepoolletv1alpha1.VolumeUIDLabel]
 
 	var image string
 	var volumeSnapshotRef *corev1.LocalObjectReference

--- a/broker/volumebroker/server/volume_create_test.go
+++ b/broker/volumebroker/server/volume_create_test.go
@@ -52,8 +52,9 @@ var _ = Describe("CreateVolume", func() {
 		By("inspecting the ironcore volume")
 		Expect(ironcoreVolume.Labels).To(Equal(map[string]string{
 			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
-			volumebrokerv1alpha1.CreatedLabel: "true",
-			volumebrokerv1alpha1.ManagerLabel: volumebrokerv1alpha1.VolumeBrokerManager,
+			volumebrokerv1alpha1.CreatedLabel:    "true",
+			volumebrokerv1alpha1.ManagerLabel:    volumebrokerv1alpha1.VolumeBrokerManager,
+			volumepoolletv1alpha1.VolumeUIDLabel: "foobar",
 		}))
 		encodedIRIAnnotations, err := apiutils.EncodeAnnotationsAnnotation(nil)
 		Expect(err).NotTo(HaveOccurred())

--- a/broker/volumebroker/server/volume_list.go
+++ b/broker/volumebroker/server/volume_list.go
@@ -7,18 +7,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ironcore-dev/controller-utils/metautils"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/common"
 	volumebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/volumebroker/api/v1alpha1"
-	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
-	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -206,38 +202,4 @@ func (s *Server) ListVolumes(ctx context.Context, req *iri.ListVolumesRequest) (
 	return &iri.ListVolumesResponse{
 		Volumes: volumes,
 	}, nil
-}
-
-func (s *Server) SetVolumeUIDLabelToAllVolumes(ctx context.Context) error {
-	volumeList := &storagev1alpha1.VolumeList{}
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Listing brokered volumes")
-	if err := s.listManagedAndCreated(ctx, volumeList, nil); err != nil {
-		return fmt.Errorf("error listing ironcore volumes: %w", err)
-	}
-
-	for i := range volumeList.Items {
-		volume := &volumeList.Items[i]
-		labels, err := apiutils.GetLabelsAnnotation(volume)
-		if err != nil {
-			return fmt.Errorf("failed to get labels annotation: %w", err)
-		}
-		if labels == nil {
-			log.Info("Labels are nil", "name", volume.Name, "namespace", volume.Namespace)
-			continue
-		}
-
-		volumeUid := labels[volumepoolletv1alpha1.VolumeUIDLabel]
-		if volumeUid == "" {
-			log.Info("Volume uid label is empty", "name", volume.Name, "namespace", volume.Namespace)
-			continue
-		}
-		log.Info("Setting volume uid label for", "name", volume.Name, "namespace", volume.Namespace, "labelKey", volumepoolletv1alpha1.VolumeUIDLabel, "labelValue", volumeUid)
-		base := volume.DeepCopy()
-		metautils.SetLabel(volume, volumepoolletv1alpha1.VolumeUIDLabel, volumeUid)
-		if err := s.client.Patch(ctx, volume, client.MergeFrom(base)); err != nil {
-			return fmt.Errorf("error patching volume uid label: %w", err)
-		}
-	}
-	return nil
 }

--- a/broker/volumebroker/server/volume_list_test.go
+++ b/broker/volumebroker/server/volume_list_test.go
@@ -4,15 +4,19 @@
 package server_test
 
 import (
+	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
+	volumebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/volumebroker/api/v1alpha1"
 	irimeta "github.com/ironcore-dev/ironcore/iri/apis/meta/v1alpha1"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	poolletutils "github.com/ironcore-dev/ironcore/poollet/common/utils"
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("ListVolumes", func() {
-	_, srv := SetupTest()
+	ns, srv := SetupTest()
 	volumeClass := SetupVolumeClass()
 
 	It("should correctly list volumes", func(ctx SpecContext) {
@@ -43,5 +47,59 @@ var _ = Describe("ListVolumes", func() {
 
 		By("listing the Volumes")
 		Expect(srv.ListVolumes(ctx, &iri.ListVolumesRequest{})).To(HaveField("Volumes", ConsistOf(Volumes...)))
+	})
+
+	It("should set volume uid label to all existing volumes", func(ctx SpecContext) {
+		By("creating multiple volumes")
+		res, err := srv.CreateVolume(ctx, &iri.CreateVolumeRequest{
+			Volume: &iri.Volume{
+				Metadata: &irimeta.ObjectMetadata{
+					Labels: map[string]string{
+						volumepoolletv1alpha1.VolumeUIDLabel: "foobar",
+					},
+				},
+				Spec: &iri.VolumeSpec{
+					Class: volumeClass.Name,
+					Resources: &iri.VolumeResources{
+						StorageBytes: 100,
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).NotTo(BeNil())
+
+		ironcoreVolume := &storagev1alpha1.Volume{}
+		ironcoreVolumeKey := client.ObjectKey{Namespace: ns.Name, Name: res.Volume.Metadata.Id}
+		Expect(k8sClient.Get(ctx, ironcoreVolumeKey, ironcoreVolume)).To(Succeed())
+		Expect(ironcoreVolume.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
+			volumebrokerv1alpha1.CreatedLabel:    "true",
+			volumebrokerv1alpha1.ManagerLabel:    volumebrokerv1alpha1.VolumeBrokerManager,
+			volumepoolletv1alpha1.VolumeUIDLabel: "foobar",
+		}))
+
+		base := ironcoreVolume.DeepCopy()
+		delete(ironcoreVolume.Labels, volumepoolletv1alpha1.VolumeUIDLabel)
+		Expect(k8sClient.Patch(ctx, ironcoreVolume, client.MergeFrom(base))).To(Succeed())
+		Expect(k8sClient.Get(ctx, ironcoreVolumeKey, ironcoreVolume)).To(Succeed())
+		Expect(ironcoreVolume.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
+			volumebrokerv1alpha1.CreatedLabel: "true",
+			volumebrokerv1alpha1.ManagerLabel: volumebrokerv1alpha1.VolumeBrokerManager,
+		}))
+
+		Expect(srv.SetVolumeUIDLabelToAllVolumes(ctx)).NotTo(HaveOccurred())
+
+		By("getting the ironcore volume")
+		Expect(k8sClient.Get(ctx, ironcoreVolumeKey, ironcoreVolume)).To(Succeed())
+
+		By("inspecting the ironcore volume")
+		Expect(ironcoreVolume.Labels).To(Equal(map[string]string{
+			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
+			volumebrokerv1alpha1.CreatedLabel:    "true",
+			volumebrokerv1alpha1.ManagerLabel:    volumebrokerv1alpha1.VolumeBrokerManager,
+			volumepoolletv1alpha1.VolumeUIDLabel: "foobar",
+		}))
 	})
 })

--- a/broker/volumebroker/server/volume_list_test.go
+++ b/broker/volumebroker/server/volume_list_test.go
@@ -12,6 +12,7 @@ import (
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -89,7 +90,8 @@ var _ = Describe("ListVolumes", func() {
 			volumebrokerv1alpha1.ManagerLabel: volumebrokerv1alpha1.VolumeBrokerManager,
 		}))
 
-		Expect(srv.SetVolumeUIDLabelToAllVolumes(ctx)).NotTo(HaveOccurred())
+		log := ctrl.LoggerFrom(ctx)
+		Expect(srv.SetVolumeUIDLabelToAllVolumes(ctx, log)).NotTo(HaveOccurred())
 
 		By("getting the ironcore volume")
 		Expect(k8sClient.Get(ctx, ironcoreVolumeKey, ironcoreVolume)).To(Succeed())

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -484,22 +484,16 @@ func (r *VolumeReconciler) reconcile(ctx context.Context, log logr.Logger, volum
 	}
 
 	log.V(1).Info("Listing volumes")
-	res, err := r.VolumeRuntime.ListVolumes(ctx, &iri.ListVolumesRequest{
-		Filter: &iri.VolumeFilter{
-			LabelSelector: map[string]string{
-				volumepoolletv1alpha1.VolumeUIDLabel: string(volume.UID),
-			},
-		},
-	})
+	volumes, err := r.listIRIVolumesByUID(ctx, volume.UID)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error listing volumes: %w", err)
 	}
 
-	switch len(res.Volumes) {
+	switch len(volumes) {
 	case 0:
 		return r.create(ctx, log, volume)
 	case 1:
-		iriVolume := res.Volumes[0]
+		iriVolume := volumes[0]
 		if err := r.update(ctx, log, volume, iriVolume); err != nil {
 			return ctrl.Result{}, fmt.Errorf("error updating volume: %w", err)
 		}


### PR DESCRIPTION
# Proposed Changes

- Modify `volumebroker` to filter volumes before aggregation and to add `volumepoollet.ironcore.dev/volume-uid` label with parent volume uid as value in `CreateVolume` function
- Modify `volumepoollet` to list and delete volumes using `volumepoollet.ironcore.dev/volume-uid` label
- Set volume uid label to all existing brokered volumes on startup as part up migration to avoid volume recreation.

Fixes #1405 