### PR TITLE
Removed deprecated `Requeue`

### DIFF
--- a/internal/controllers/compute/machineclass_controller.go
+++ b/internal/controllers/compute/machineclass_controller.go
@@ -80,7 +80,7 @@ func (r *MachineClassReconciler) delete(ctx context.Context, log logr.Logger, ma
 	}
 	if len(machines) > 0 {
 		log.V(1).Info("Machine class is still in use", "ReferencingMachineNames", r.collectMachineNames(machines))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	machines, err = r.listReferencingMachinesWithReader(ctx, r.APIReader, machineClass)
@@ -89,7 +89,7 @@ func (r *MachineClassReconciler) delete(ctx context.Context, log logr.Logger, ma
 	}
 	if len(machines) > 0 {
 		log.V(1).Info("Machine class is still in use", "ReferencingMachineNames", r.collectMachineNames(machines))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Machine class is not in use anymore, removing finalizer")

--- a/internal/controllers/networking/network_release_controller.go
+++ b/internal/controllers/networking/network_release_controller.go
@@ -129,7 +129,7 @@ func (r *NetworkReleaseReconciler) reconcile(ctx context.Context, log logr.Logge
 			return ctrl.Result{}, fmt.Errorf("error releasing network: %w", err)
 		}
 		log.V(1).Info("Network was updated, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Reconciled")

--- a/internal/controllers/networking/networkinterface_release_controller.go
+++ b/internal/controllers/networking/networkinterface_release_controller.go
@@ -106,7 +106,7 @@ func (r *NetworkInterfaceReleaseReconciler) reconcile(ctx context.Context, log l
 			return ctrl.Result{}, fmt.Errorf("error releasing network interface: %w", err)
 		}
 		log.V(1).Info("Network interface was updated, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Reconciled")

--- a/internal/controllers/networking/virtualip_release_controller.go
+++ b/internal/controllers/networking/virtualip_release_controller.go
@@ -105,7 +105,7 @@ func (r *VirtualIPReleaseReconciler) reconcile(ctx context.Context, log logr.Log
 			return ctrl.Result{}, fmt.Errorf("error releasing virtual IP: %w", err)
 		}
 		log.V(1).Info("Virtual IP was updated, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Reconciled")

--- a/internal/controllers/storage/bucketclass_controller.go
+++ b/internal/controllers/storage/bucketclass_controller.go
@@ -79,7 +79,7 @@ func (r *BucketClassReconciler) delete(ctx context.Context, log logr.Logger, buc
 	}
 	if len(buckets) > 0 {
 		log.V(1).Info("Bucket class is still in use", "ReferencingBucketNames", r.collectBucketNames(buckets))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	buckets, err = r.listReferencingBucketsWithReader(ctx, r.APIReader, bucketClass)
@@ -88,7 +88,7 @@ func (r *BucketClassReconciler) delete(ctx context.Context, log logr.Logger, buc
 	}
 	if len(buckets) > 0 {
 		log.V(1).Info("Bucket class is still in use", "ReferencingBucketNames", r.collectBucketNames(buckets))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Bucket Class is not used anymore, removing finalizer")

--- a/internal/controllers/storage/volume_release_controller.go
+++ b/internal/controllers/storage/volume_release_controller.go
@@ -106,7 +106,7 @@ func (r *VolumeReleaseReconciler) reconcile(ctx context.Context, log logr.Logger
 			return ctrl.Result{}, fmt.Errorf("error releasing volume: %w", err)
 		}
 		log.V(1).Info("Volume was updated, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Reconciled")

--- a/internal/controllers/storage/volumeclass_controller.go
+++ b/internal/controllers/storage/volumeclass_controller.go
@@ -79,7 +79,7 @@ func (r *VolumeClassReconciler) delete(ctx context.Context, log logr.Logger, vol
 	}
 	if len(volumes) > 0 {
 		log.V(1).Info("Volume class is still in use", "ReferencingVolumeNames", r.collectVolumeNames(volumes))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	volumes, err = r.listReferencingVolumesWithReader(ctx, r.APIReader, volumeClass)
@@ -88,7 +88,7 @@ func (r *VolumeClassReconciler) delete(ctx context.Context, log logr.Logger, vol
 	}
 	if len(volumes) > 0 {
 		log.V(1).Info("Volume class is still in use", "ReferencingVolumeNames", r.collectVolumeNames(volumes))
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Volume Class is not used anymore, removing finalizer")

--- a/poollet/bucketpoollet/controllers/bucket_controller.go
+++ b/poollet/bucketpoollet/controllers/bucket_controller.go
@@ -139,7 +139,7 @@ func (r *BucketReconciler) deleteGone(ctx context.Context, log logr.Logger, buck
 	}
 	if !ok {
 		log.V(1).Info("Not all iri buckets are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted gone")
@@ -212,7 +212,7 @@ func (r *BucketReconciler) delete(ctx context.Context, log logr.Logger, bucket *
 	}
 	if !ok {
 		log.V(1).Info("Not all iri buckets are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted all iri buckets, removing finalizer")
@@ -309,7 +309,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, log logr.Logger, bucke
 	}
 	if modified {
 		log.V(1).Info("Added finalizer, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 	log.V(1).Info("Finalizer is present")
 
@@ -320,7 +320,7 @@ func (r *BucketReconciler) reconcile(ctx context.Context, log logr.Logger, bucke
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Listing buckets")

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -183,7 +183,7 @@ func (r *MachineReconciler) deleteGone(ctx context.Context, log logr.Logger, mac
 	}
 	if !ok {
 		log.V(1).Info("Not all machines are gone yet, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 	log.V(1).Info("Deleted gone")
 	return ctrl.Result{}, nil
@@ -234,7 +234,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, log logr.Logger, mach
 	}
 	if modified {
 		log.V(1).Info("Added finalizer, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 	log.V(1).Info("Finalizer is present")
 
@@ -245,7 +245,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, log logr.Logger, mach
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	nics, err := r.getNetworkInterfacesForMachine(ctx, machine)
@@ -334,6 +334,10 @@ func (r *MachineReconciler) create(
 	if !ok {
 		log.V(1).Info("Machine is not yet ready")
 		return ctrl.Result{}, nil
+	}
+
+	if machine.Spec.Image != "" { //nolint:staticcheck
+		r.Eventf(machine, corev1.EventTypeWarning, "ImageRefDeprecated", "Image reference in spec.image is deprecated")
 	}
 
 	log.V(1).Info("Creating machine")

--- a/poollet/machinepoollet/controllers/machinepool_controller.go
+++ b/poollet/machinepoollet/controllers/machinepool_controller.go
@@ -148,7 +148,7 @@ func (r *MachinePoolReconciler) reconcile(ctx context.Context, log logr.Logger, 
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Listing machine classes")

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -146,7 +146,7 @@ func (r *VolumeReconciler) deleteGone(ctx context.Context, log logr.Logger, volu
 	}
 	if !ok {
 		log.V(1).Info("Not all iri volumes are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted gone")
@@ -219,7 +219,7 @@ func (r *VolumeReconciler) delete(ctx context.Context, log logr.Logger, volume *
 	}
 	if !ok {
 		log.V(1).Info("Not all iri volumes are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted all iri volumes, removing finalizer")
@@ -469,7 +469,7 @@ func (r *VolumeReconciler) reconcile(ctx context.Context, log logr.Logger, volum
 	}
 	if modified {
 		log.V(1).Info("Added finalizer, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 	log.V(1).Info("Finalizer is present")
 
@@ -480,7 +480,7 @@ func (r *VolumeReconciler) reconcile(ctx context.Context, log logr.Logger, volum
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Listing volumes")

--- a/poollet/volumepoollet/controllers/volumepool_controller.go
+++ b/poollet/volumepoollet/controllers/volumepool_controller.go
@@ -140,7 +140,7 @@ func (r *VolumePoolReconciler) reconcile(ctx context.Context, log logr.Logger, v
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Listing volume classes")

--- a/poollet/volumepoollet/controllers/volumesnapshot_controller.go
+++ b/poollet/volumepoollet/controllers/volumesnapshot_controller.go
@@ -94,7 +94,7 @@ func (r *VolumeSnapshotReconciler) deleteGone(ctx context.Context, log logr.Logg
 	}
 	if !ok {
 		log.V(1).Info("Not all iri volume snapshots are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted gone")
@@ -139,7 +139,7 @@ func (r *VolumeSnapshotReconciler) delete(ctx context.Context, log logr.Logger, 
 	}
 	if !ok {
 		log.V(1).Info("Not all iri volume snapshots are gone, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Deleted all iri volume snapshots, removing finalizer")
@@ -294,7 +294,7 @@ func (r *VolumeSnapshotReconciler) reconcile(ctx context.Context, log logr.Logge
 	}
 	if modified {
 		log.V(1).Info("Added finalizer, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 	log.V(1).Info("Finalizer is present")
 
@@ -305,7 +305,7 @@ func (r *VolumeSnapshotReconciler) reconcile(ctx context.Context, log logr.Logge
 	}
 	if modified {
 		log.V(1).Info("Removed reconcile annotation, requeueing")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 1}, nil
 	}
 
 	log.V(1).Info("Listing volume snapshots")


### PR DESCRIPTION
# Proposed Changes

- Removed deprecated `Requeue`
- Event if deprecated `Machine.Image` field is used
