### PR TITLE
Added `Version` command to `irictl-machine` 

### DIFF
--- a/irictl-machine/cmd/irictl-machine/irictlmachine/get/get.go
+++ b/irictl-machine/cmd/irictl-machine/irictlmachine/get/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/event"
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/machine"
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/status"
+	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/version"
 	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Com
 		machine.Command(streams, clientFactory),
 		status.Command(streams, clientFactory),
 		event.Command(streams, clientFactory),
+		version.Command(streams, clientFactory),
 	)
 
 	return cmd

--- a/irictl-machine/cmd/irictl-machine/irictlmachine/get/version/version.go
+++ b/irictl-machine/cmd/irictl-machine/irictlmachine/get/version/version.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/common"
+	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
+	"github.com/ironcore-dev/ironcore/irictl/renderer"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Command {
+	var (
+		outputOpts = clientFactory.OutputOptions()
+	)
+
+	cmd := &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			log := ctrl.LoggerFrom(ctx)
+
+			client, cleanup, err := clientFactory.Client()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := cleanup(); err != nil {
+					log.Error(err, "Error cleaning up")
+				}
+			}()
+
+			render, err := outputOpts.Renderer("table")
+			if err != nil {
+				return err
+			}
+
+			return Run(cmd.Context(), streams, client, render)
+		},
+	}
+
+	outputOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func Run(ctx context.Context, streams clicommon.Streams, client iri.MachineRuntimeClient, render renderer.Renderer) error {
+	res, err := client.Version(ctx, &iri.VersionRequest{})
+	if err != nil {
+		return fmt.Errorf("error getting version: %w", err)
+	}
+
+	return render.Render(res, streams.Out)
+}

--- a/irictl-machine/tableconverters/version.go
+++ b/irictl-machine/tableconverters/version.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tableconverters
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl/api"
+	"github.com/ironcore-dev/ironcore/irictl/tableconverter"
+)
+
+var (
+	versionsHeaders = []api.Header{
+		{Name: "Name"},
+		{Name: "Version"},
+	}
+
+	VersionResponse = tableconverter.Funcs[*iri.VersionResponse]{
+		Headers: tableconverter.Headers(versionsHeaders),
+		Rows: tableconverter.SingleRowFrom(func(versionInfo *iri.VersionResponse) (api.Row, error) {
+			return api.Row{
+				versionInfo.RuntimeName,
+				versionInfo.RuntimeVersion,
+			}, nil
+		}),
+	}
+
+	VersionResponseSlice = tableconverter.SliceFuncs[*iri.VersionResponse](VersionResponse)
+)
+
+func init() {
+	RegistryBuilder.Register(
+		tableconverter.ToTagAndTypedAny[*iri.VersionResponse](VersionResponse),
+		tableconverter.ToTagAndTypedAny[[]*iri.VersionResponse](VersionResponseSlice),
+	)
+}


### PR DESCRIPTION
# Proposed Changes

- Inject `version` and `commit` variables into build flags for broker components.
- Update `irictl` commands to support get version information.


Fixes #1298 