### PR TITLE
Added command to retrieve `Version` in `irictl` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ FROM builder AS machinebroker-builder
 # TODO: Remove irictl-machine once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/machinebroker ./broker/machinebroker/cmd/machinebroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS}" -a -o bin/machinebroker ./broker/machinebroker/cmd/machinebroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
 
 FROM builder AS irictl-machine-builder
@@ -73,7 +73,7 @@ FROM builder AS volumebroker-builder
 # TODO: Remove irictl-volume once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/volumebroker ./broker/volumebroker/cmd/volumebroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS}" -a -o bin/volumebroker ./broker/volumebroker/cmd/volumebroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-volume ./irictl-volume/cmd/irictl-volume/main.go
 
 FROM builder AS irictl-volume-builder
@@ -94,7 +94,7 @@ FROM builder AS bucketbroker-builder
 # TODO: Remove irictl-bucket once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/bucketbroker ./broker/bucketbroker/cmd/bucketbroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS}" -a -o bin/bucketbroker ./broker/bucketbroker/cmd/bucketbroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-bucket ./irictl-bucket/cmd/irictl-bucket/main.go
 
 FROM builder AS irictl-bucket-builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY utils/ utils/
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG LDFLAGS
 
 RUN mkdir bin
 
@@ -51,7 +52,7 @@ FROM builder AS machinebroker-builder
 # TODO: Remove irictl-machine once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/machinebroker ./broker/machinebroker/cmd/machinebroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/machinebroker ./broker/machinebroker/cmd/machinebroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-machine ./irictl-machine/cmd/irictl-machine/main.go
 
 FROM builder AS irictl-machine-builder
@@ -72,7 +73,7 @@ FROM builder AS volumebroker-builder
 # TODO: Remove irictl-volume once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/volumebroker ./broker/volumebroker/cmd/volumebroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/volumebroker ./broker/volumebroker/cmd/volumebroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-volume ./irictl-volume/cmd/irictl-volume/main.go
 
 FROM builder AS irictl-volume-builder
@@ -93,7 +94,7 @@ FROM builder AS bucketbroker-builder
 # TODO: Remove irictl-bucket once debug containers are more broadly available.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/bucketbroker ./broker/bucketbroker/cmd/bucketbroker/main.go && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="${LDFLAGS} -s -w" -a -o bin/bucketbroker ./broker/bucketbroker/cmd/bucketbroker/main.go && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags="-s -w" -a -o bin/irictl-bucket ./irictl-bucket/cmd/irictl-bucket/main.go
 
 FROM builder AS irictl-bucket-builder

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,16 @@ BUCKETPOOLLET_IMG ?= bucketpoollet:latest
 BUCKETBROKER_IMG ?= bucketbroker:latest
 IRICTL_BUCKET_IMG ?= irictl-bucket:latest
 
+# LDFLAGS for the build targets
+VERSION=$(shell git describe --tags --abbrev=0)
+COMMIT=$(shell git log -n1 --format="%h")
+MACHINEBROKER_VERSION = github.com/ironcore-dev/ironcore/broker/machinebroker/version.Version
+MACHINEBROKER_COMMIT = github.com/ironcore-dev/ironcore/broker/machinebroker/version.Commit
+VOLUMEBROKER_VERSION = github.com/ironcore-dev/ironcore/broker/volumebroker/version.Version
+VOLUMEBROKER_COMMIT = github.com/ironcore-dev/ironcore/broker/volumebroker/version.Commit
+BUCKETBROKER_VERSION = github.com/ironcore-dev/ironcore/broker/bucketbroker/version.Version
+BUCKETBROKER_COMMIT = github.com/ironcore-dev/ironcore/broker/bucketbroker/version.Commit
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.34.0
 
@@ -189,7 +199,7 @@ docker-build-machinepoollet: ## Build machinepoollet image.
 
 .PHONY: docker-build-machinebroker
 docker-build-machinebroker: ## Build machinebroker image.
-	docker build --target machinebroker -t ${MACHINEBROKER_IMG} .
+	docker build --build-arg LDFLAGS="-X $(MACHINEBROKER_VERSION)=$(VERSION) -X $(MACHINEBROKER_COMMIT)=$(COMMIT)" --target machinebroker -t ${MACHINEBROKER_IMG} .
 
 .PHONY: docker-build-irictl-machine
 docker-build-irictl-machine: ## Build irictl-machine image.
@@ -201,7 +211,7 @@ docker-build-volumepoollet: ## Build volumepoollet image.
 
 .PHONY: docker-build-volumebroker
 docker-build-volumebroker: ## Build volumebroker image.
-	docker build --target volumebroker -t ${VOLUMEBROKER_IMG} .
+	docker build --build-arg LDFLAGS="-X $(VOLUMEBROKER_VERSION)=$(VERSION) -X $(VOLUMEBROKER_COMMIT)=$(COMMIT)" --target volumebroker -t ${VOLUMEBROKER_IMG} .
 
 .PHONY: docker-build-irictl-volume
 docker-build-irictl-volume: ## Build irictl-volume image.
@@ -209,7 +219,7 @@ docker-build-irictl-volume: ## Build irictl-volume image.
 
 .PHONY: docker-build-bucketpoollet
 docker-build-bucketpoollet: ## Build bucketpoollet image.
-	docker build --target bucketpoollet -t ${BUCKETPOOLLET_IMG} .
+	docker build --build-arg LDFLAGS="-X $(BUCKETBROKER_VERSION)=$(VERSION) -X $(BUCKETBROKER_COMMIT)=$(COMMIT)" --target bucketpoollet -t ${BUCKETPOOLLET_IMG} .
 
 .PHONY: docker-build-bucketbroker
 docker-build-bucketbroker: ## Build bucketbroker image.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ BUCKETBROKER_IMG ?= bucketbroker:latest
 IRICTL_BUCKET_IMG ?= irictl-bucket:latest
 
 # LDFLAGS for the build targets
+LDFLAGS ?= -s -w
 VERSION=$(shell git describe --tags --abbrev=0)
 COMMIT=$(shell git log -n1 --format="%h")
 MACHINEBROKER_VERSION = github.com/ironcore-dev/ironcore/broker/machinebroker/version.Version
@@ -199,7 +200,7 @@ docker-build-machinepoollet: ## Build machinepoollet image.
 
 .PHONY: docker-build-machinebroker
 docker-build-machinebroker: ## Build machinebroker image.
-	docker build --build-arg LDFLAGS="-X $(MACHINEBROKER_VERSION)=$(VERSION) -X $(MACHINEBROKER_COMMIT)=$(COMMIT)" --target machinebroker -t ${MACHINEBROKER_IMG} .
+	docker build --build-arg LDFLAGS="${LDFLAGS} -X $(MACHINEBROKER_VERSION)=$(VERSION) -X $(MACHINEBROKER_COMMIT)=$(COMMIT)" --target machinebroker -t ${MACHINEBROKER_IMG} .
 
 .PHONY: docker-build-irictl-machine
 docker-build-irictl-machine: ## Build irictl-machine image.
@@ -211,7 +212,7 @@ docker-build-volumepoollet: ## Build volumepoollet image.
 
 .PHONY: docker-build-volumebroker
 docker-build-volumebroker: ## Build volumebroker image.
-	docker build --build-arg LDFLAGS="-X $(VOLUMEBROKER_VERSION)=$(VERSION) -X $(VOLUMEBROKER_COMMIT)=$(COMMIT)" --target volumebroker -t ${VOLUMEBROKER_IMG} .
+	docker build --build-arg LDFLAGS="${LDFLAGS} -X $(VOLUMEBROKER_VERSION)=$(VERSION) -X $(VOLUMEBROKER_COMMIT)=$(COMMIT)" --target volumebroker -t ${VOLUMEBROKER_IMG} .
 
 .PHONY: docker-build-irictl-volume
 docker-build-irictl-volume: ## Build irictl-volume image.
@@ -219,7 +220,7 @@ docker-build-irictl-volume: ## Build irictl-volume image.
 
 .PHONY: docker-build-bucketpoollet
 docker-build-bucketpoollet: ## Build bucketpoollet image.
-	docker build --build-arg LDFLAGS="-X $(BUCKETBROKER_VERSION)=$(VERSION) -X $(BUCKETBROKER_COMMIT)=$(COMMIT)" --target bucketpoollet -t ${BUCKETPOOLLET_IMG} .
+	docker build --build-arg LDFLAGS="${LDFLAGS} -X $(BUCKETBROKER_VERSION)=$(VERSION) -X $(BUCKETBROKER_COMMIT)=$(COMMIT)" --target bucketpoollet -t ${BUCKETPOOLLET_IMG} .
 
 .PHONY: docker-build-bucketbroker
 docker-build-bucketbroker: ## Build bucketbroker image.

--- a/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/get.go
+++ b/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ironcore-dev/ironcore/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/bucket"
 	"github.com/ironcore-dev/ironcore/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/bucketclass"
 	"github.com/ironcore-dev/ironcore/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/event"
+	"github.com/ironcore-dev/ironcore/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/version"
 	irictlcmd "github.com/ironcore-dev/ironcore/irictl/cmd"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ func Command(streams irictlcmd.Streams, clientFactory common.ClientFactory) *cob
 		bucket.Command(streams, clientFactory),
 		bucketclass.Command(streams, clientFactory),
 		event.Command(streams, clientFactory),
+		version.Command(streams, clientFactory),
 	)
 
 	return cmd

--- a/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/version/version.go
+++ b/irictl-bucket/cmd/irictl-bucket/irictlbucket/get/version/version.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl-bucket/cmd/irictl-bucket/irictlbucket/common"
+	irictlcmd "github.com/ironcore-dev/ironcore/irictl/cmd"
+	"github.com/ironcore-dev/ironcore/irictl/renderer"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Command(streams irictlcmd.Streams, clientFactory common.ClientFactory) *cobra.Command {
+	var (
+		outputOpts = common.NewOutputOptions()
+	)
+
+	cmd := &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			log := ctrl.LoggerFrom(ctx)
+
+			client, cleanup, err := clientFactory.New()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := cleanup(); err != nil {
+					log.Error(err, "Error cleaning up")
+				}
+			}()
+
+			render, err := outputOpts.Renderer("table")
+			if err != nil {
+				return err
+			}
+
+			return Run(cmd.Context(), streams, client, render)
+		},
+	}
+
+	outputOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func Run(ctx context.Context, streams irictlcmd.Streams, client iri.BucketRuntimeClient, render renderer.Renderer) error {
+	res, err := client.Version(ctx, &iri.VersionRequest{})
+	if err != nil {
+		return fmt.Errorf("error getting version: %w", err)
+	}
+
+	return render.Render(res, streams.Out)
+}

--- a/irictl-bucket/tableconverters/version.go
+++ b/irictl-bucket/tableconverters/version.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tableconverters
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/bucket/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl/api"
+	"github.com/ironcore-dev/ironcore/irictl/tableconverter"
+)
+
+var (
+	versionsHeaders = []api.Header{
+		{Name: "Name"},
+		{Name: "Version"},
+	}
+
+	VersionResponse = tableconverter.Funcs[*iri.VersionResponse]{
+		Headers: tableconverter.Headers(versionsHeaders),
+		Rows: tableconverter.SingleRowFrom(func(versionInfo *iri.VersionResponse) (api.Row, error) {
+			return api.Row{
+				versionInfo.RuntimeName,
+				versionInfo.RuntimeVersion,
+			}, nil
+		}),
+	}
+
+	VersionResponseSlice = tableconverter.SliceFuncs[*iri.VersionResponse](VersionResponse)
+)
+
+func init() {
+	RegistryBuilder.Register(
+		tableconverter.ToTagAndTypedAny[*iri.VersionResponse](VersionResponse),
+		tableconverter.ToTagAndTypedAny[[]*iri.VersionResponse](VersionResponseSlice),
+	)
+}

--- a/irictl-machine/cmd/irictl-machine/irictlmachine/get/get.go
+++ b/irictl-machine/cmd/irictl-machine/irictlmachine/get/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/event"
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/machine"
 	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/status"
+	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/get/version"
 	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Com
 		machine.Command(streams, clientFactory),
 		status.Command(streams, clientFactory),
 		event.Command(streams, clientFactory),
+		version.Command(streams, clientFactory),
 	)
 
 	return cmd

--- a/irictl-machine/cmd/irictl-machine/irictlmachine/get/version/version.go
+++ b/irictl-machine/cmd/irictl-machine/irictlmachine/get/version/version.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl-machine/cmd/irictl-machine/irictlmachine/common"
+	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
+	"github.com/ironcore-dev/ironcore/irictl/renderer"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Command(streams clicommon.Streams, clientFactory common.Factory) *cobra.Command {
+	var (
+		outputOpts = clientFactory.OutputOptions()
+	)
+
+	cmd := &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			log := ctrl.LoggerFrom(ctx)
+
+			client, cleanup, err := clientFactory.Client()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := cleanup(); err != nil {
+					log.Error(err, "Error cleaning up")
+				}
+			}()
+
+			render, err := outputOpts.Renderer("table")
+			if err != nil {
+				return err
+			}
+
+			return Run(cmd.Context(), streams, client, render)
+		},
+	}
+
+	outputOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func Run(ctx context.Context, streams clicommon.Streams, client iri.MachineRuntimeClient, render renderer.Renderer) error {
+	res, err := client.Version(ctx, &iri.VersionRequest{})
+	if err != nil {
+		return fmt.Errorf("error getting version: %w", err)
+	}
+
+	return render.Render(res, streams.Out)
+}

--- a/irictl-machine/tableconverters/version.go
+++ b/irictl-machine/tableconverters/version.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tableconverters
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/machine/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl/api"
+	"github.com/ironcore-dev/ironcore/irictl/tableconverter"
+)
+
+var (
+	versionsHeaders = []api.Header{
+		{Name: "Name"},
+		{Name: "Version"},
+	}
+
+	VersionResponse = tableconverter.Funcs[*iri.VersionResponse]{
+		Headers: tableconverter.Headers(versionsHeaders),
+		Rows: tableconverter.SingleRowFrom(func(versionInfo *iri.VersionResponse) (api.Row, error) {
+			return api.Row{
+				versionInfo.RuntimeName,
+				versionInfo.RuntimeVersion,
+			}, nil
+		}),
+	}
+
+	VersionResponseSlice = tableconverter.SliceFuncs[*iri.VersionResponse](VersionResponse)
+)
+
+func init() {
+	RegistryBuilder.Register(
+		tableconverter.ToTagAndTypedAny[*iri.VersionResponse](VersionResponse),
+		tableconverter.ToTagAndTypedAny[[]*iri.VersionResponse](VersionResponseSlice),
+	)
+}

--- a/irictl-volume/cmd/irictl-volume/irictlvolume/get/get.go
+++ b/irictl-volume/cmd/irictl-volume/irictlvolume/get/get.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/common"
 	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/get/event"
 	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/get/status"
+	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/get/version"
 	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/get/volume"
 	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/get/volumesnapshot"
 	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
@@ -23,6 +24,7 @@ func Command(streams clicommon.Streams, clientFactory common.ClientFactory) *cob
 		status.Command(streams, clientFactory),
 		event.Command(streams, clientFactory),
 		volumesnapshot.Command(streams, clientFactory),
+		version.Command(streams, clientFactory),
 	)
 
 	return cmd

--- a/irictl-volume/cmd/irictl-volume/irictlvolume/get/version/version.go
+++ b/irictl-volume/cmd/irictl-volume/irictlvolume/get/version/version.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"context"
+	"fmt"
+
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl-volume/cmd/irictl-volume/irictlvolume/common"
+	clicommon "github.com/ironcore-dev/ironcore/irictl/cmd"
+	"github.com/ironcore-dev/ironcore/irictl/renderer"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Command(streams clicommon.Streams, clientFactory common.ClientFactory) *cobra.Command {
+	var (
+		outputOpts = common.NewOutputOptions()
+	)
+
+	cmd := &cobra.Command{
+		Use: "version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			log := ctrl.LoggerFrom(ctx)
+
+			client, cleanup, err := clientFactory.New()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := cleanup(); err != nil {
+					log.Error(err, "Error cleaning up")
+				}
+			}()
+
+			render, err := outputOpts.Renderer("table")
+			if err != nil {
+				return err
+			}
+
+			return Run(cmd.Context(), streams, client, render)
+		},
+	}
+
+	outputOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func Run(ctx context.Context, streams clicommon.Streams, client iri.VolumeRuntimeClient, render renderer.Renderer) error {
+	res, err := client.Version(ctx, &iri.VersionRequest{})
+	if err != nil {
+		return fmt.Errorf("error getting version: %w", err)
+	}
+
+	return render.Render(res, streams.Out)
+}

--- a/irictl-volume/tableconverters/version.go
+++ b/irictl-volume/tableconverters/version.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package tableconverters
+
+import (
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
+	"github.com/ironcore-dev/ironcore/irictl/api"
+	"github.com/ironcore-dev/ironcore/irictl/tableconverter"
+)
+
+var (
+	versionsHeaders = []api.Header{
+		{Name: "Name"},
+		{Name: "Version"},
+	}
+
+	VersionResponse = tableconverter.Funcs[*iri.VersionResponse]{
+		Headers: tableconverter.Headers(versionsHeaders),
+		Rows: tableconverter.SingleRowFrom(func(versionInfo *iri.VersionResponse) (api.Row, error) {
+			return api.Row{
+				versionInfo.RuntimeName,
+				versionInfo.RuntimeVersion,
+			}, nil
+		}),
+	}
+
+	VersionResponseSlice = tableconverter.SliceFuncs[*iri.VersionResponse](VersionResponse)
+)
+
+func init() {
+	RegistryBuilder.Register(
+		tableconverter.ToTagAndTypedAny[*iri.VersionResponse](VersionResponse),
+		tableconverter.ToTagAndTypedAny[[]*iri.VersionResponse](VersionResponseSlice),
+	)
+}


### PR DESCRIPTION
# Proposed Changes

- Inject `version` and `commit` variables into build flags for broker components.
- Update `irictl` commands to support get version information.

Fixes #1298 