### PR TITLE
Update `lastTransitionTime` for volume and nic in the machineCondition

### DIFF
--- a/api/compute/v1alpha1/machine_types.go
+++ b/api/compute/v1alpha1/machine_types.go
@@ -189,6 +189,15 @@ const (
 // MachineConditionType is a type a MachineCondition can have.
 type MachineConditionType string
 
+const (
+	// MachineConditionReady indicates that the machine is ready.
+	MachineConditionReady MachineConditionType = "MachineReady"
+	// MachineConditionVolumesReady indicates that the volumes are ready.
+	MachineConditionVolumesReady MachineConditionType = "VolumesReady"
+	// MachineConditionNetworkInterfacesReady indicates that the network interfaces are ready.
+	MachineConditionNetworkInterfacesReady MachineConditionType = "NetworkInterfacesReady"
+)
+
 // MachineCondition is one of the conditions of a machine.
 type MachineCondition struct {
 	// Type is the type of the condition.

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -565,14 +565,30 @@ func (r *MachineReconciler) computeVolumesReadyCondition(volumeStatuses []comput
 	}
 
 	status, reason, message := corev1.ConditionTrue, "VolumesReady", "All volumes are ready"
+	var lastTransitionTime *metav1.Time
 
 	for _, vs := range volumeStatuses {
 		if vs.State != computev1alpha1.VolumeStateAttached {
 			status = corev1.ConditionFalse
 			reason = fmt.Sprintf("VolumeNotReady: %s", vs.Name)
 			message = fmt.Sprintf("Volume %s is not attached (state: %s)", vs.Name, vs.State)
+			lastTransitionTime = vs.LastStateTransitionTime
 			break
 		}
+	}
+
+	if status == corev1.ConditionTrue {
+		for _, vs := range volumeStatuses {
+			if vs.LastStateTransitionTime != nil {
+				lastTransitionTime = vs.LastStateTransitionTime
+				break
+			}
+		}
+	}
+
+	transitionTime := now
+	if lastTransitionTime != nil {
+		transitionTime = *lastTransitionTime
 	}
 
 	return computev1alpha1.MachineCondition{
@@ -580,7 +596,7 @@ func (r *MachineReconciler) computeVolumesReadyCondition(volumeStatuses []comput
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
-		LastTransitionTime: now,
+		LastTransitionTime: transitionTime,
 	}
 }
 
@@ -590,14 +606,30 @@ func (r *MachineReconciler) computeNetworkInterfacesReadyCondition(nicStatuses [
 	}
 
 	status, reason, message := corev1.ConditionTrue, "NetworkInterfacesReady", "All network interfaces are ready"
+	var lastTransitionTime *metav1.Time
 
 	for _, nicStatus := range nicStatuses {
 		if nicStatus.State != computev1alpha1.NetworkInterfaceStateAttached {
 			status = corev1.ConditionFalse
 			reason = fmt.Sprintf("NetworkInterfaceNotReady: %s", nicStatus.Name)
 			message = fmt.Sprintf("Network interface %s is not attached (state: %s)", nicStatus.Name, nicStatus.State)
+			lastTransitionTime = nicStatus.LastStateTransitionTime
 			break
 		}
+	}
+
+	if status == corev1.ConditionTrue {
+		for _, nicStatus := range nicStatuses {
+			if nicStatus.LastStateTransitionTime != nil {
+				lastTransitionTime = nicStatus.LastStateTransitionTime
+				break
+			}
+		}
+	}
+
+	transitionTime := now
+	if lastTransitionTime != nil {
+		transitionTime = *lastTransitionTime
 	}
 
 	return computev1alpha1.MachineCondition{
@@ -605,7 +637,7 @@ func (r *MachineReconciler) computeNetworkInterfacesReadyCondition(nicStatuses [
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
-		LastTransitionTime: now,
+		LastTransitionTime: transitionTime,
 	}
 }
 

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -552,7 +553,7 @@ func (r *MachineReconciler) computeMachineReadyCondition(state computev1alpha1.M
 	}
 
 	return computev1alpha1.MachineCondition{
-		Type:               "MachineReady",
+		Type:               computev1alpha1.MachineConditionReady,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
@@ -585,9 +586,8 @@ func (r *MachineReconciler) computeVolumesReadyCondition(volumeStatuses []comput
 
 	if status == corev1.ConditionTrue {
 		for _, vs := range volumeStatuses {
-			if vs.LastStateTransitionTime != nil {
+			if vs.LastStateTransitionTime != nil && (lastTransitionTime == nil || vs.LastStateTransitionTime.After(lastTransitionTime.Time)) {
 				lastTransitionTime = vs.LastStateTransitionTime
-				break
 			}
 		}
 	}
@@ -598,7 +598,7 @@ func (r *MachineReconciler) computeVolumesReadyCondition(volumeStatuses []comput
 	}
 
 	return computev1alpha1.MachineCondition{
-		Type:               computev1alpha1.MachineConditionType("VolumesReady"),
+		Type:               computev1alpha1.MachineConditionVolumesReady,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
@@ -627,9 +627,8 @@ func (r *MachineReconciler) computeNetworkInterfacesReadyCondition(nicStatuses [
 
 	if status == corev1.ConditionTrue {
 		for _, nicStatus := range nicStatuses {
-			if nicStatus.LastStateTransitionTime != nil {
+			if nicStatus.LastStateTransitionTime != nil && (lastTransitionTime == nil || nicStatus.LastStateTransitionTime.After(lastTransitionTime.Time)) {
 				lastTransitionTime = nicStatus.LastStateTransitionTime
-				break
 			}
 		}
 	}
@@ -640,7 +639,7 @@ func (r *MachineReconciler) computeNetworkInterfacesReadyCondition(nicStatuses [
 	}
 
 	return computev1alpha1.MachineCondition{
-		Type:               computev1alpha1.MachineConditionType("NetworkInterfacesReady"),
+		Type:               computev1alpha1.MachineConditionNetworkInterfacesReady,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
@@ -667,7 +666,33 @@ func (r *MachineReconciler) mergeMachineConditions(
 		}
 	}
 
-	return updated
+	// Group conditions by type and keep only the latest 10 per type (by LastTransitionTime)
+	const maxConditionsPerType = 10
+	conditionsByType := make(map[string][]computev1alpha1.MachineCondition)
+	for _, cond := range updated {
+		condType := string(cond.Type)
+		conditionsByType[condType] = append(conditionsByType[condType], cond)
+	}
+
+	var result []computev1alpha1.MachineCondition
+	// Sort condition types for deterministic ordering
+	types := make([]string, 0, len(conditionsByType))
+	for t := range conditionsByType {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	for _, t := range types {
+		conds := conditionsByType[t]
+		sort.Slice(conds, func(i, j int) bool {
+			return conds[i].LastTransitionTime.Before(&conds[j].LastTransitionTime)
+		})
+		if len(conds) > maxConditionsPerType {
+			conds = conds[len(conds)-maxConditionsPerType:]
+		}
+		result = append(result, conds...)
+	}
+
+	return result
 }
 
 func (r *MachineReconciler) prepareIRIPower(power computev1alpha1.Power) (iri.Power, error) {
@@ -1019,7 +1044,7 @@ func (r *MachineReconciler) enqueueMachinesReferencingNetworkInterface() handler
 			},
 			r.matchingWatchLabel(),
 		); err != nil {
-			log.Error(err, "Error listing machines using network interface", "NetworkInterfaceKey", client.ObjectKeyFromObject(nic))
+			log.Error(err, "Error listing machines using secret", "NetworkInterfaceKey", client.ObjectKeyFromObject(nic))
 			return nil
 		}
 

--- a/poollet/machinepoollet/controllers/machine_controller_test.go
+++ b/poollet/machinepoollet/controllers/machine_controller_test.go
@@ -197,7 +197,7 @@ var _ = Describe("MachineController", func() {
 		))
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Status.Conditions", ContainElement(MatchFields(IgnoreExtras, Fields{
-				"Type":               Equal(computev1alpha1.MachineConditionType("Ready")),
+				"Type":               Equal(computev1alpha1.MachineConditionType("MachineReady")),
 				"Status":             Equal(corev1.ConditionFalse),
 				"Reason":             Equal("Pending"),
 				"Message":            Equal("Machine is pending"),
@@ -206,15 +206,15 @@ var _ = Describe("MachineController", func() {
 			HaveField("Status.Conditions", ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type":               Equal(computev1alpha1.MachineConditionType("VolumesReady")),
 				"Status":             Equal(corev1.ConditionFalse),
-				"Reason":             Equal(fmt.Sprintf("VolumeNotReady: %s", "primary")),
-				"Message":            Equal(fmt.Sprintf("Volume %s is not attached (state: %s)", "primary", "Pending")),
+				"Reason":             Equal(fmt.Sprintf("VolumeNotReady: %s", volume.Name)),
+				"Message":            Equal(fmt.Sprintf("Volume %s is not attached (state: %s)", volume.Name, "Pending")),
 				"LastTransitionTime": Not(BeNil()),
 			}))),
 			HaveField("Status.Conditions", ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type":               Equal(computev1alpha1.MachineConditionType("NetworkInterfacesReady")),
 				"Status":             Equal(corev1.ConditionFalse),
-				"Reason":             Equal(fmt.Sprintf("NetworkInterfaceNotReady: %s", "primary")),
-				"Message":            Equal(fmt.Sprintf("Network interface %s is not attached (state: %s)", "primary", "Pending")),
+				"Reason":             Equal(fmt.Sprintf("NetworkInterfaceNotReady: %s", nic.Name)),
+				"Message":            Equal(fmt.Sprintf("Network interface %s is not attached (state: %s)", nic.Name, "Pending")),
 				"LastTransitionTime": Not(BeNil()),
 			}))),
 		))
@@ -507,7 +507,7 @@ var _ = Describe("MachineController", func() {
 		By("waiting for the machine conditions to be updated")
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Status.Conditions", ContainElement(MatchFields(IgnoreExtras, Fields{
-				"Type":               Equal(computev1alpha1.MachineConditionType("Ready")),
+				"Type":               Equal(computev1alpha1.MachineConditionType("MachineReady")),
 				"Status":             Equal(corev1.ConditionTrue),
 				"Reason":             Equal("Running"),
 				"Message":            Equal("Machine is running"),
@@ -527,7 +527,7 @@ var _ = Describe("MachineController", func() {
 		By("waiting for the machine conditions to be updated")
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Status.Conditions", ContainElement(MatchFields(IgnoreExtras, Fields{
-				"Type":               Equal(computev1alpha1.MachineConditionType("Ready")),
+				"Type":               Equal(computev1alpha1.MachineConditionType("MachineReady")),
 				"Status":             Equal(corev1.ConditionFalse),
 				"Reason":             Equal("Terminating"),
 				"Message":            Equal("Machine is terminating or terminated"),


### PR DESCRIPTION
# Proposed Changes
- Update `machineCondition` for volume and nic with the respective `lastStateTransitionTime` 
- Extend `machineCondition` implementation to persist the `Conditions` history
/ref #1343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status updates now preserve existing conditions and only add/update changed ones.
  * Ready condition renamed to "MachineReady"; new "VolumesReady" and "NetworkInterfacesReady" condition types introduced.
  * Volume and network-interface readiness compute per-resource transition timestamps with sensible fallbacks.
  * Readiness messages reference actual volume and network-interface names.

* **Tests**
  * Tests updated to expect the renamed condition type and dynamic readiness messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->