### PR TITLE
Add architecture hints to ephemeral volumes

### DIFF
--- a/api/common/v1alpha1/common_types.go
+++ b/api/common/v1alpha1/common_types.go
@@ -32,6 +32,9 @@ const (
 	// some ephemeral controller is managing the resource.
 	EphemeralManagedByAnnotation = "common.ironcore.dev/ephemeral-managed-by"
 
+	// MachineArchitectureLabel is a label that indicates the machine architecture.
+	MachineArchitectureLabel = "common.ironcore.dev/architecture"
+
 	// DefaultEphemeralManager is the default ironcoreephemeral manager.
 	DefaultEphemeralManager = "ephemeral-manager"
 )

--- a/internal/controllers/compute/machine_ephemeralvolume_controller_test.go
+++ b/internal/controllers/compute/machine_ephemeralvolume_controller_test.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
+	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/utils/annotations"
 	. "github.com/ironcore-dev/ironcore/utils/testing"
@@ -12,7 +13,9 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 )
@@ -20,6 +23,7 @@ import (
 var _ = Describe("MachineEphemeralVolumeController", func() {
 	ns := SetupNamespace(&k8sClient)
 	machineClass := SetupMachineClass()
+	volumeClass := SetupVolumeClass()
 
 	It("should manage ephemeral volumes for a machine", func(ctx SpecContext) {
 		By("creating a volume that will be referenced by the machine")
@@ -88,6 +92,58 @@ var _ = Describe("MachineEphemeralVolumeController", func() {
 
 		By("waiting for the undesired controlled volume to be gone")
 		Eventually(Get(undesiredControlledVolume)).Should(Satisfy(apierrors.IsNotFound))
+	})
+
+	It("should manage ephemeral volumes for a machine and setting architecture hint", func(ctx SpecContext) {
+		By("creating a machine")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+				Volumes: []computev1alpha1.Volume{
+					{
+						Name: "ephem-volume",
+						VolumeSource: computev1alpha1.VolumeSource{
+							Ephemeral: &computev1alpha1.EphemeralVolumeSource{
+								VolumeTemplate: &storagev1alpha1.VolumeTemplateSpec{
+									Spec: storagev1alpha1.VolumeSpec{
+										VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
+										Resources: corev1alpha1.ResourceList{
+											corev1alpha1.ResourceStorage: resource.MustParse("500Mi"),
+										},
+										DataSource: storagev1alpha1.VolumeDataSource{
+											OSImage: &storagev1alpha1.OSDataSource{
+												Image: "test-os-image",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+
+		By("waiting for the ephemeral volume to exist")
+		ephemVolume := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns.Name,
+				Name:      computev1alpha1.MachineEphemeralVolumeName(machine.Name, "ephem-volume"),
+			},
+		}
+		Eventually(Get(ephemVolume)).Should(Succeed())
+
+		Eventually(Object(ephemVolume)).Should(SatisfyAll(
+			HaveField("Spec.DataSource.OSImage", &storagev1alpha1.OSDataSource{
+				Image:        "test-os-image",
+				Architecture: ptr.To("amd64"),
+			}),
+		))
 	})
 
 	It("should not delete externally managed volumes for a machine", func(ctx SpecContext) {

--- a/internal/controllers/compute/suite_test.go
+++ b/internal/controllers/compute/suite_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	commonv1alpha1 "github.com/ironcore-dev/ironcore/api/common/v1alpha1"
+
 	"github.com/ironcore-dev/controller-utils/buildutils"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
@@ -177,10 +179,27 @@ func SetupMachineClass() *computev1alpha1.MachineClass {
 		*machineClass = computev1alpha1.MachineClass{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "machine-class-",
+				Labels: map[string]string{
+					commonv1alpha1.MachineArchitectureLabel: "amd64",
+				},
 			},
 			Capabilities: corev1alpha1.ResourceList{
 				corev1alpha1.ResourceCPU:    resource.MustParse("1"),
 				corev1alpha1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	})
+}
+
+func SetupVolumeClass() *storagev1alpha1.VolumeClass {
+	return SetupObjectStruct[*storagev1alpha1.VolumeClass](&k8sClient, func(volumeClass *storagev1alpha1.VolumeClass) {
+		*volumeClass = storagev1alpha1.VolumeClass{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "volume-class-",
+			},
+			Capabilities: corev1alpha1.ResourceList{
+				corev1alpha1.ResourceIOPS: resource.MustParse("500"),
+				corev1alpha1.ResourceTPS:  resource.MustParse("500Mi"),
 			},
 		}
 	})


### PR DESCRIPTION
# Proposed Changes

- Add architecture hints to ephemeral volumes

Fixes #1434 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ephemeral volumes now inherit machine architecture (when available) so OS images created for ephemeral volumes include architecture hints.

* **Tests**
  * Added test coverage validating architecture-aware ephemeral volume creation and OS image architecture propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->