### PR TITLE
Provide injection mechanism to set custom received message size for gRPC clients in a `poollet`

### DIFF
--- a/iri/remote/volume/runtime.go
+++ b/iri/remote/volume/runtime.go
@@ -7,19 +7,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ironcore-dev/ironcore/iri/apis/volume"
-	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/ironcore-dev/ironcore/iri/apis/volume"
+	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
 )
 
 type remoteRuntime struct {
 	client iri.VolumeRuntimeClient
 }
 
-func NewRemoteRuntime(endpoint string) (volume.RuntimeService, error) {
+func NewRemoteRuntime(endpoint string, size int) (volume.RuntimeService, error) {
 	conn, err := grpc.NewClient(endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(size)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error dialing: %w", err)
@@ -33,9 +35,11 @@ func NewRemoteRuntime(endpoint string) (volume.RuntimeService, error) {
 func (r *remoteRuntime) Version(ctx context.Context, req *iri.VersionRequest) (*iri.VersionResponse, error) {
 	return r.client.Version(ctx, req)
 }
+
 func (r *remoteRuntime) ListEvents(ctx context.Context, req *iri.ListEventsRequest) (*iri.ListEventsResponse, error) {
 	return r.client.ListEvents(ctx, req)
 }
+
 func (r *remoteRuntime) ListVolumes(ctx context.Context, request *iri.ListVolumesRequest) (*iri.ListVolumesResponse, error) {
 	return r.client.ListVolumes(ctx, request)
 }

--- a/poollet/common/utils/runtime.go
+++ b/poollet/common/utils/runtime.go
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+const DefaultGrpcMaxRecvMsgSize = 1024 * 1024 * 12


### PR DESCRIPTION
# Proposed Changes

- introduces a flag for poollet to provide custom received message size for gRPC clients

Fixes #1442 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--grpc-max-received-msg-size` command-line flag to configure maximum message size handling, with a default value of 12 MB. This allows users to adjust message size limits based on their specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->