### PR TITLE
Add release branching and cherry picking process

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -1,0 +1,22 @@
+name: Create Release Branch
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.0"
+
+jobs:
+  create-release-branch:
+    name: Create release branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create release branch
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Extract major.minor from tag (e.g. v0.1.0 -> release-v0.1)
+          BRANCH="release-${TAG%.*}"
+          git switch -c "${BRANCH}"
+          git push origin "${BRANCH}"

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -18,5 +18,5 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           # Extract major.minor from tag (e.g. v0.1.0 -> release-v0.1)
           BRANCH="release-${TAG%.*}"
-          git switch -c "${BRANCH}"
+          git switch "${BRANCH}" 2>/dev/null || git switch -c "${BRANCH}"
           git push origin "${BRANCH}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - release-**
   pull_request_target:
     types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:
   update_release_draft:
+    name: Run release drafter
     permissions:
       # write permission is required to create a github release
       contents: write
@@ -19,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
+      # or a release branch
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
+          commitish: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <PR-number> <release-branch>"
+    echo ""
+    echo "Cherry-pick a merged PR into a release branch and open a new PR."
+    echo ""
+    echo "Examples:"
+    echo "  $0 123 release-v0.1"
+    echo "  $0 456 release-v0.2"
+    echo ""
+    echo "Prerequisites:"
+    echo "  - gh CLI installed and authenticated"
+    echo "  - Clean working tree"
+    exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+PR_NUMBER="$1"
+RELEASE_BRANCH="$2"
+
+# Verify gh CLI is available
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI is not installed. See https://cli.github.com/"
+    exit 1
+fi
+
+# Verify clean working tree
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is not clean. Please commit or stash your changes."
+    exit 1
+fi
+
+# Verify the release branch exists on remote
+if ! git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" &>/dev/null; then
+    echo "Error: branch '${RELEASE_BRANCH}' does not exist on remote."
+    exit 1
+fi
+
+# Get the merge commit SHA for the PR
+MERGE_COMMIT=$(gh pr view "${PR_NUMBER}" --json mergeCommit --jq '.mergeCommit.oid')
+if [[ -z "${MERGE_COMMIT}" ]]; then
+    echo "Error: PR #${PR_NUMBER} has no merge commit. Is it merged?"
+    exit 1
+fi
+
+PR_TITLE=$(gh pr view "${PR_NUMBER}" --json title --jq '.title')
+CHERRY_PICK_BRANCH="cherry-pick-${PR_NUMBER}-into-${RELEASE_BRANCH}"
+
+echo "Cherry-picking PR #${PR_NUMBER} (\"${PR_TITLE}\") into ${RELEASE_BRANCH}"
+echo "  Merge commit: ${MERGE_COMMIT}"
+echo "  Branch: ${CHERRY_PICK_BRANCH}"
+echo ""
+
+# Fetch latest remote state
+git fetch origin "${RELEASE_BRANCH}"
+
+# Create cherry-pick branch from the release branch
+git switch -c "${CHERRY_PICK_BRANCH}" "origin/${RELEASE_BRANCH}"
+
+# Cherry-pick the merge commit using the first parent
+if ! git cherry-pick -x -m1 "${MERGE_COMMIT}"; then
+    echo ""
+    echo "Cherry-pick has conflicts. Please resolve them, then run:"
+    echo "  git cherry-pick --continue"
+    echo "  git push origin ${CHERRY_PICK_BRANCH}"
+    echo "  gh pr create --base ${RELEASE_BRANCH} --title \"🍒 [${RELEASE_BRANCH}] ${PR_TITLE}\" --body \"Cherry-pick of #${PR_NUMBER} into ${RELEASE_BRANCH}.\""
+    exit 1
+fi
+
+# Push and create PR
+git push origin "${CHERRY_PICK_BRANCH}"
+gh pr create \
+    --base "${RELEASE_BRANCH}" \
+    --title "🍒 [${RELEASE_BRANCH}] ${PR_TITLE}" \
+    --body "Cherry-pick of #${PR_NUMBER} into \`${RELEASE_BRANCH}\`."
+
+echo ""
+echo "Done."

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -44,7 +44,7 @@ fi
 
 # Get the merge commit SHA for the PR
 MERGE_COMMIT=$(gh pr view "${PR_NUMBER}" --json mergeCommit --jq '.mergeCommit.oid')
-if [[ -z "${MERGE_COMMIT}" ]]; then
+if [[ -z "${MERGE_COMMIT}" || "${MERGE_COMMIT}" == "null" ]]; then
     echo "Error: PR #${PR_NUMBER} has no merge commit. Is it merged?"
     exit 1
 fi
@@ -61,10 +61,26 @@ echo ""
 git fetch origin "${RELEASE_BRANCH}"
 
 # Create cherry-pick branch from the release branch
+if git show-ref --verify --quiet "refs/heads/${CHERRY_PICK_BRANCH}"; then
+    echo "Error: local branch '${CHERRY_PICK_BRANCH}' already exists."
+    echo "If it is left over from a previous attempt, delete it with:"
+    echo "  git branch -D ${CHERRY_PICK_BRANCH}"
+    exit 1
+fi
 git switch -c "${CHERRY_PICK_BRANCH}" "origin/${RELEASE_BRANCH}"
 
-# Cherry-pick the merge commit using the first parent
-if ! git cherry-pick -x -m1 "${MERGE_COMMIT}"; then
+# Fetch the merge commit (it may not exist locally yet)
+git fetch origin "${MERGE_COMMIT}"
+
+# Use -m1 only for true merge commits (more than one parent)
+PARENT_COUNT=$(git rev-list --parents -n1 "${MERGE_COMMIT}" | wc -w)
+# rev-list output includes the commit itself, so >2 words means multiple parents
+CHERRY_PICK_ARGS=("-x")
+if [[ "${PARENT_COUNT}" -gt 2 ]]; then
+    CHERRY_PICK_ARGS+=("-m1")
+fi
+
+if ! git cherry-pick "${CHERRY_PICK_ARGS[@]}" "${MERGE_COMMIT}"; then
     echo ""
     echo "Cherry-pick has conflicts. Please resolve them, then run:"
     echo "  git cherry-pick --continue"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated creation of release branches from tagged releases.
  * Release notes drafting now includes release branches in addition to main.
  * Added a script to automate cherry-picking merged PRs into release branches and open corresponding PRs, with guidance for conflict resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->