### PR TITLE
Add autolabeler job to release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,25 +5,30 @@ on:
     branches:
       - main
       - release-**
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened, synchronize ]
-  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   update_release_draft:
     name: Run release drafter
-    permissions:
-      # write permission is required to create a github release
-      contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
       - uses: release-drafter/release-drafter@v7
         with:
-          config-name: release-drafter.yml
           commitish: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
+  auto_label:
+    name: Run autolabeler
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - release-**
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 permissions:
@@ -16,7 +16,7 @@ permissions:
 jobs:
   update_release_draft:
     name: Run release drafter
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request_target'
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   auto_label:
     name: Run autolabeler
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request_target'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,13 +10,15 @@ on:
     types: [ opened, reopened, synchronize ]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:
   update_release_draft:
     name: Run release drafter
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual workflow trigger to allow on-demand runs.
  * Added top-level workflow permissions and tightened job-level permissions for safer execution.
  * Split behavior so release draft updates skip PR-targeted events and introduced an automatic PR-labeling job for same-repository PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->