### PR TITLE
Enhance importas rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,35 @@ linters:
   settings:
     importas:
       alias:
+        # APIs
         - pkg: github.com/ironcore-dev/ironcore/api/(\w+)/(v[\w\d]+)
-          alias: $1$2
+          alias: ${1}${2}
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}
+        # Listers
+        - pkg: github.com/ironcore-dev/client-go/listers/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}listers
+        - pkg: k8s.io/client-go/listers/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}listers
+        # Informers
+        - pkg: github.com/ironcore-dev/client-go/informers
+          alias: ironcoreinformers
+        - pkg: github.com/ironcore-dev/client-go/informers/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}informers
+        - pkg: k8s.io/client-go/informers
+          alias: k8sinformers
+        - pkg: k8s.io/client-go/informers/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}informers
+        # Internal
         - pkg: github.com/ironcore-dev/ironcore/internal/apis/(\w+)
-          alias: $1
+          alias: ${1}
         - pkg: github.com/ironcore-dev/ironcore/internal/client/(\w+)
           alias: ${1}client
+        # Apply Configurations
+        - pkg: github.com/ironcore-dev/client-go/applyconfigurations/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}apply
+        - pkg: k8s.io/client-go/applyconfigurations/(\w+)/(v[\w\d]+)
+          alias: ${1}${2}apply
     misspell:
       ignore-rules:
         - strat
@@ -42,6 +65,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - remotecommand # Exclude this for now
 severity:
   default: error
 formatters:

--- a/broker/bucketbroker/server/event_list.go
+++ b/broker/bucketbroker/server/event_list.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,7 +27,7 @@ const (
 
 func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	log := ctrl.LoggerFrom(ctx)
-	bucketEventList := &v1.EventList{}
+	bucketEventList := &corev1.EventList{}
 	selectorField := fields.Set{
 		InvolvedObjectKindSelector:       InvolvedObjectKind,
 		InvolvedObjectAPIVersionSelector: storagev1alpha1.SchemeGroupVersion.String(),

--- a/broker/machinebroker/server/event_list.go
+++ b/broker/machinebroker/server/event_list.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -30,7 +30,7 @@ const (
 
 func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	log := ctrl.LoggerFrom(ctx)
-	machineEventList := &v1.EventList{}
+	machineEventList := &corev1.EventList{}
 	selectorField := fields.Set{
 		InvolvedObjectKindSelector:       InvolvedObjectKind,
 		InvolvedObjectAPIVersionSelector: computev1alpha1.SchemeGroupVersion.String(),

--- a/broker/volumebroker/server/event_list.go
+++ b/broker/volumebroker/server/event_list.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,7 +27,7 @@ const (
 
 func (s *Server) listEvents(ctx context.Context) ([]*irievent.Event, error) {
 	log := ctrl.LoggerFrom(ctx)
-	volumeEventList := &v1.EventList{}
+	volumeEventList := &corev1.EventList{}
 	selectorField := fields.Set{
 		InvolvedObjectKindSelector:       InvolvedObjectKind,
 		InvolvedObjectAPIVersionSelector: storagev1alpha1.SchemeGroupVersion.String(),

--- a/internal/controllers/core/certificate/compute/machinepool.go
+++ b/internal/controllers/core/certificate/compute/machinepool.go
@@ -11,7 +11,7 @@ import (
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
 	"golang.org/x/exp/slices"
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -64,7 +64,7 @@ func ValidateMachinePoolClientCSR(req *x509.CertificateRequest, usages sets.Set[
 var (
 	MachinePoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
 		IsMachinePoolClientCert,
-		authv1.ResourceAttributes{
+		authorizationv1.ResourceAttributes{
 			Group:       certificatesv1.GroupName,
 			Resource:    "certificatesigningrequests",
 			Verb:        "create",

--- a/internal/controllers/core/certificate/generic/certificate.go
+++ b/internal/controllers/core/certificate/generic/certificate.go
@@ -8,25 +8,25 @@ import (
 	"encoding/pem"
 	"fmt"
 
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 )
 
 type CertificateSigningRequestRecognizer interface {
 	Recognize(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool
-	Permission() authv1.ResourceAttributes
+	Permission() authorizationv1.ResourceAttributes
 	SuccessMessage() string
 }
 
 type certificateSigningRequestRecognizer struct {
 	recognize      func(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool
-	permission     authv1.ResourceAttributes
+	permission     authorizationv1.ResourceAttributes
 	successMessage string
 }
 
 func NewCertificateSigningRequestRecognizer(
 	recognize func(csr *certificatesv1.CertificateSigningRequest, x509CR *x509.CertificateRequest) bool,
-	permission authv1.ResourceAttributes,
+	permission authorizationv1.ResourceAttributes,
 	successMessage string,
 ) CertificateSigningRequestRecognizer {
 	return &certificateSigningRequestRecognizer{
@@ -40,7 +40,7 @@ func (r *certificateSigningRequestRecognizer) Recognize(csr *certificatesv1.Cert
 	return r.recognize(csr, x509CR)
 }
 
-func (r *certificateSigningRequestRecognizer) Permission() authv1.ResourceAttributes {
+func (r *certificateSigningRequestRecognizer) Permission() authorizationv1.ResourceAttributes {
 	return r.permission
 }
 

--- a/internal/controllers/core/certificate/networking/networkplugin.go
+++ b/internal/controllers/core/certificate/networking/networkplugin.go
@@ -11,7 +11,7 @@ import (
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
 	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
 	"golang.org/x/exp/slices"
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -64,7 +64,7 @@ func ValidateNetworkPluginClientCSR(req *x509.CertificateRequest, usages sets.Se
 var (
 	NetworkPluginRecognizer = generic.NewCertificateSigningRequestRecognizer(
 		IsNetworkPluginClientCert,
-		authv1.ResourceAttributes{
+		authorizationv1.ResourceAttributes{
 			Group:       certificatesv1.GroupName,
 			Resource:    "certificatesigningrequests",
 			Verb:        "create",

--- a/internal/controllers/core/certificate/storage/bucketpool.go
+++ b/internal/controllers/core/certificate/storage/bucketpool.go
@@ -11,7 +11,7 @@ import (
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
 	"golang.org/x/exp/slices"
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -64,7 +64,7 @@ func ValidateBucketPoolClientCSR(req *x509.CertificateRequest, usages sets.Set[c
 var (
 	BucketPoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
 		IsBucketPoolClientCert,
-		authv1.ResourceAttributes{
+		authorizationv1.ResourceAttributes{
 			Group:       certificatesv1.GroupName,
 			Resource:    "certificatesigningrequests",
 			Verb:        "create",

--- a/internal/controllers/core/certificate/storage/volumepool.go
+++ b/internal/controllers/core/certificate/storage/volumepool.go
@@ -11,7 +11,7 @@ import (
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
 	"golang.org/x/exp/slices"
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -64,7 +64,7 @@ func ValidateVolumePoolClientCSR(req *x509.CertificateRequest, usages sets.Set[c
 var (
 	VolumePoolRecognizer = generic.NewCertificateSigningRequestRecognizer(
 		IsVolumePoolClientCert,
-		authv1.ResourceAttributes{
+		authorizationv1.ResourceAttributes{
 			Group:       certificatesv1.GroupName,
 			Resource:    "certificatesigningrequests",
 			Verb:        "create",

--- a/internal/controllers/core/certificateapproval_controller.go
+++ b/internal/controllers/core/certificateapproval_controller.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
-	authv1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,14 +81,14 @@ func (r *CertificateApprovalReconciler) Reconcile(ctx context.Context, req ctrl.
 	return ctrl.Result{}, nil
 }
 
-func (r *CertificateApprovalReconciler) authorize(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, attrs authv1.ResourceAttributes) (bool, error) {
-	extra := make(map[string]authv1.ExtraValue)
+func (r *CertificateApprovalReconciler) authorize(ctx context.Context, csr *certificatesv1.CertificateSigningRequest, attrs authorizationv1.ResourceAttributes) (bool, error) {
+	extra := make(map[string]authorizationv1.ExtraValue)
 	for k, v := range csr.Spec.Extra {
-		extra[k] = authv1.ExtraValue(v)
+		extra[k] = authorizationv1.ExtraValue(v)
 	}
 
-	sar := &authv1.SubjectAccessReview{
-		Spec: authv1.SubjectAccessReviewSpec{
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
 			User:               csr.Spec.Username,
 			UID:                csr.Spec.UID,
 			Groups:             csr.Spec.Groups,

--- a/utils/rest/configrotator_test.go
+++ b/utils/rest/configrotator_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/ironcore-dev/ironcore/utils/rest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/authorization/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -119,8 +119,8 @@ var _ = Describe("ConfigRotator", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("asserting we are not authenticated")
-		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &v1.SelfSubjectRulesReview{
-			Spec: v1.SelfSubjectRulesReviewSpec{
+		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &authorizationv1.SelfSubjectRulesReview{
+			Spec: authorizationv1.SelfSubjectRulesReviewSpec{
 				Namespace: corev1.NamespaceDefault,
 			},
 		}, metav1.CreateOptions{})
@@ -141,8 +141,8 @@ var _ = Describe("ConfigRotator", func() {
 		}).Should(Succeed())
 
 		By("asserting we are now authenticated")
-		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &v1.SelfSubjectRulesReview{
-			Spec: v1.SelfSubjectRulesReviewSpec{
+		_, err = c.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, &authorizationv1.SelfSubjectRulesReview{
+			Spec: authorizationv1.SelfSubjectRulesReviewSpec{
 				Namespace: corev1.NamespaceDefault,
 			},
 		}, metav1.CreateOptions{})

--- a/utils/rest/rest_suite_test.go
+++ b/utils/rest/rest_suite_test.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	authv1 "k8s.io/api/authentication/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	DeferCleanup(testEnv.Stop)
 
-	Expect(authv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(authenticationv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Proposed Changes

Using the `importas` linter, we now have enhanced rules:
* APIs (like `corev1` / `computev1alpha1`) are now consistently named.
* Same applies for listers, informers and applyconfigurations

Fixed the existing code to respect the new linter rules where it wasn't already the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Kubernetes import aliases across the codebase for consistency.
  * Updated related code and tests to use the new aliases without behavior changes.

* **Chores**
  * Enhanced linter configuration with expanded import-alias mappings and new exclusion paths for improved analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->