### PR TITLE
Drop vgopath from API code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,14 +90,13 @@ manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition o
 	./hack/replace.sh config/apiserver/rbac/bucketpool_role.yaml 's/manager-role/storage.ironcore.dev:system:bucketpools/g'
 
 .PHONY: generate
-generate: vgopath models-schema openapi-gen proto
-	VGOPATH=$(VGOPATH) \
+generate: models-schema openapi-gen proto
 	MODELS_SCHEMA=$(MODELS_SCHEMA) \
 	OPENAPI_GEN=$(OPENAPI_GEN) \
 	./hack/update-codegen.sh
 
 .PHONY: proto
-proto: goimports vgopath buf protoc-gen-go protoc-gen-go-grpc
+proto: goimports buf protoc-gen-go protoc-gen-go-grpc
 	$(BUF) generate --template buf.gen.yaml
 	$(GOIMPORTS) -w ./iri
 
@@ -346,7 +345,6 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 OPENAPI_EXTRACTOR ?= $(LOCALBIN)/openapi-extractor
 OPENAPI_GEN ?= $(LOCALBIN)/openapi-gen
-VGOPATH ?= $(LOCALBIN)/vgopath
 GEN_CRD_API_REFERENCE_DOCS ?= $(LOCALBIN)/gen-crd-api-reference-docs
 ADDLICENSE ?= $(LOCALBIN)/addlicense
 BUF ?= $(LOCALBIN)/buf
@@ -358,7 +356,6 @@ PROTOC_GEN_GO_GRPC ?= $(LOCALBIN)/protoc-gen-go-grpc
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.1.1
-VGOPATH_VERSION ?= v0.1.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= v0.3.0
 ADDLICENSE_VERSION ?= v1.1.1
@@ -386,12 +383,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 openapi-gen: $(OPENAPI_GEN) ## Download openapi-gen locally if necessary.
 $(OPENAPI_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(OPENAPI_GEN),k8s.io/kube-openapi/cmd/openapi-gen,$(OPENAPI_GEN_VERSION))
-
-.PHONY: vgopath
-vgopath: $(VGOPATH) ## Download vgopath locally if necessary.
-.PHONY: $(VGOPATH)
-$(VGOPATH): $(LOCALBIN)
-	$(call go-install-tool,$(VGOPATH),github.com/ironcore-dev/vgopath,$(VGOPATH_VERSION))
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -11,18 +11,10 @@ THIS_PKG="github.com/ironcore-dev/ironcore"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_ROOT="$SCRIPT_DIR/.."
 
-VGOPATH="$VGOPATH"
 MODELS_SCHEMA="$MODELS_SCHEMA"
 OPENAPI_GEN="$OPENAPI_GEN"
 
-VIRTUAL_GOPATH="$(mktemp -d)"
-trap 'rm -rf "$VIRTUAL_GOPATH"' EXIT
-
-# Setup virtual GOPATH so the codegen tools work as expected.
-(cd "$PROJECT_ROOT"; go mod download && "$VGOPATH" -o "$VIRTUAL_GOPATH")
-
-export GOROOT="${GOROOT:-"$(go env GOROOT)"}"
-export GOPATH="$VIRTUAL_GOPATH"
+(cd "$PROJECT_ROOT"; go mod download)
 
 CODE_GEN_DIR=$(go list -m -f '{{.Dir}}' k8s.io/code-generator)
 source "${CODE_GEN_DIR}/kube_codegen.sh"


### PR DESCRIPTION
# Proposed Changes

Use upstream `k8s.io/code-generator` (kube_codegen.sh) directly instead of synthesizing a virtual GOPATH via vgopath. The codegen tools have been module-aware for a while, so the GOPATH-style layout is no longer needed.

- Remove the VGOPATH variable, install target, and version pin from the Makefile, and drop vgopath as a prerequisite of `generate` and `proto`.
- Drop the mktemp + vgopath -o materialization and GOROOT/GOPATH exports from hack/update-codegen.sh; only `go mod download` remains so `go list -m` can resolve k8s.io/code-generator.

Generated output (`api/`, `client-go/`, `internal/apis/`, `iri/`) is byte-identical to before.

Fixes #1478 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build toolchain by removing an unused dependency tool and streamlining the module initialization process. Build infrastructure is now leaner with reduced complexity in code generation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->