### PR TITLE
Remove function `SetVolumeUidToAllVolumes()`

### DIFF
--- a/broker/volumebroker/cmd/volumebroker/app/app.go
+++ b/broker/volumebroker/cmd/volumebroker/app/app.go
@@ -140,9 +140,5 @@ func Run(ctx context.Context, opts Options) error {
 	if err := grpcSrv.Serve(l); err != nil {
 		return fmt.Errorf("error serving: %w", err)
 	}
-
-	if err := srv.SetVolumeUIDLabelToAllVolumes(ctx, log); err != nil {
-		return fmt.Errorf("failed to set volume uid label to all brokered volumes: %w", err)
-	}
 	return nil
 }

--- a/broker/volumebroker/server/server.go
+++ b/broker/volumebroker/server/server.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/ironcore-dev/controller-utils/metautils"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
 	ipamv1alpha1 "github.com/ironcore-dev/ironcore/api/ipam/v1alpha1"
 	networkingv1alpha1 "github.com/ironcore-dev/ironcore/api/networking/v1alpha1"
@@ -18,7 +17,6 @@ import (
 	volumebrokerv1alpha1 "github.com/ironcore-dev/ironcore/broker/volumebroker/api/v1alpha1"
 	"github.com/ironcore-dev/ironcore/broker/volumebroker/apiutils"
 	iri "github.com/ironcore-dev/ironcore/iri/apis/volume/v1alpha1"
-	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -139,39 +137,6 @@ func (s *Server) getManagedAndCreated(ctx context.Context, name string, obj clie
 			Group:    gvk.Group,
 			Resource: gvk.Kind, // Yes, kind is good enough here
 		}, key.Name)
-	}
-	return nil
-}
-
-func (s *Server) SetVolumeUIDLabelToAllVolumes(ctx context.Context, log logr.Logger) error {
-	volumeList := &storagev1alpha1.VolumeList{}
-	log.V(2).Info("Listing brokered volumes")
-	if err := s.listManagedAndCreated(ctx, volumeList, nil); err != nil {
-		return fmt.Errorf("error listing ironcore volumes: %w", err)
-	}
-
-	for i := range volumeList.Items {
-		volume := &volumeList.Items[i]
-		labels, err := apiutils.GetLabelsAnnotation(volume)
-		if err != nil {
-			return fmt.Errorf("failed to get labels annotation: %w", err)
-		}
-		if labels == nil {
-			log.V(2).Info("Labels are nil", "name", volume.Name, "namespace", volume.Namespace)
-			continue
-		}
-
-		volumeUid := labels[volumepoolletv1alpha1.VolumeUIDLabel]
-		if volumeUid == "" {
-			log.V(2).Info("Volume uid label is empty", "name", volume.Name, "namespace", volume.Namespace)
-			continue
-		}
-		log.V(2).Info("Setting volume uid label for", "name", volume.Name, "namespace", volume.Namespace, "labelKey", volumepoolletv1alpha1.VolumeUIDLabel, "labelValue", volumeUid)
-		base := volume.DeepCopy()
-		metautils.SetLabel(volume, volumepoolletv1alpha1.VolumeUIDLabel, volumeUid)
-		if err := s.client.Patch(ctx, volume, client.MergeFrom(base)); err != nil {
-			return fmt.Errorf("error patching volume uid label: %w", err)
-		}
 	}
 	return nil
 }

--- a/broker/volumebroker/server/volume_list_test.go
+++ b/broker/volumebroker/server/volume_list_test.go
@@ -12,7 +12,6 @@ import (
 	volumepoolletv1alpha1 "github.com/ironcore-dev/ironcore/poollet/volumepoollet/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,20 +87,6 @@ var _ = Describe("ListVolumes", func() {
 			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
 			volumebrokerv1alpha1.CreatedLabel: "true",
 			volumebrokerv1alpha1.ManagerLabel: volumebrokerv1alpha1.VolumeBrokerManager,
-		}))
-
-		log := ctrl.LoggerFrom(ctx)
-		Expect(srv.SetVolumeUIDLabelToAllVolumes(ctx, log)).NotTo(HaveOccurred())
-
-		By("getting the ironcore volume")
-		Expect(k8sClient.Get(ctx, ironcoreVolumeKey, ironcoreVolume)).To(Succeed())
-
-		By("inspecting the ironcore volume")
-		Expect(ironcoreVolume.Labels).To(Equal(map[string]string{
-			poolletutils.DownwardAPILabel(volumepoolletv1alpha1.VolumeDownwardAPIPrefix, "root-volume-uid"): "foobar",
-			volumebrokerv1alpha1.CreatedLabel:    "true",
-			volumebrokerv1alpha1.ManagerLabel:    volumebrokerv1alpha1.VolumeBrokerManager,
-			volumepoolletv1alpha1.VolumeUIDLabel: "foobar",
 		}))
 	})
 })


### PR DESCRIPTION
# Proposed Changes

- Deprecate function `SetVolumeUidToAllVolumes()` which was added to support backward compatibility for existing machines and stop recreation of machines.

Fixes #1481 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed automatic volume UID label initialization during server startup and removed the related server helper.
* **Tests**
  * Updated volume list tests to no longer expect UID label propagation/restoration.
* **Bug Fixes**
  * Prevented post–gRPC startup attempts to set or restore volume UID labels after the server begins serving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->