### PR TITLE
Grant RBAC for events in events.k8s.io API group

### DIFF
--- a/config/apiserver/rbac/bucketpool_role.yaml
+++ b/config/apiserver/rbac/bucketpool_role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/config/apiserver/rbac/machinepool_role.yaml
+++ b/config/apiserver/rbac/machinepool_role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/config/apiserver/rbac/volumepool_role.yaml
+++ b/config/apiserver/rbac/volumepool_role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/config/bucketpoollet-broker/poollet-rbac/role.yaml
+++ b/config/bucketpoollet-broker/poollet-rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/config/controller/rbac/role.yaml
+++ b/config/controller/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - get
@@ -21,6 +14,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/config/machinepoollet-broker/poollet-rbac/role.yaml
+++ b/config/machinepoollet-broker/poollet-rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - authentication.k8s.io
   resources:

--- a/config/volumepoollet-broker/poollet-rbac/role.yaml
+++ b/config/volumepoollet-broker/poollet-rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -22,6 +15,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - certificates.k8s.io
   resources:

--- a/internal/controllers/compute/machine_scheduler.go
+++ b/internal/controllers/compute/machine_scheduler.go
@@ -42,6 +42,7 @@ type MachineScheduler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machines,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machinepools,verbs=get;list;watch

--- a/internal/controllers/ipam/prefixallocationscheduler_controller.go
+++ b/internal/controllers/ipam/prefixallocationscheduler_controller.go
@@ -30,6 +30,7 @@ type PrefixAllocationScheduler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=ipam.ironcore.dev,resources=prefixes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=ipam.ironcore.dev,resources=prefixallocations,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=ipam.ironcore.dev,resources=prefixallocations/status,verbs=get;update;patch

--- a/internal/controllers/storage/bucket_scheduler.go
+++ b/internal/controllers/storage/bucket_scheduler.go
@@ -30,6 +30,7 @@ type BucketScheduler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=bucketpools,verbs=get;list;watch

--- a/internal/controllers/storage/volume_scheduler.go
+++ b/internal/controllers/storage/volume_scheduler.go
@@ -41,6 +41,7 @@ type VolumeScheduler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumepools,verbs=get;list;watch

--- a/poollet/bucketpoollet/controllers/bucket_controller.go
+++ b/poollet/bucketpoollet/controllers/bucket_controller.go
@@ -109,6 +109,7 @@ func (r *BucketReconciler) listIRIBucketsByUID(ctx context.Context, bucketUID ty
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=buckets/status,verbs=get;update;patch

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -76,6 +76,7 @@ type MachineReconciler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machines,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=compute.ironcore.dev,resources=machines/status,verbs=get;update;patch

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -117,6 +117,7 @@ func (r *VolumeReconciler) listIRIVolumesByUID(ctx context.Context, volumeUID ty
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumes/status,verbs=get;update;patch

--- a/poollet/volumepoollet/controllers/volumesnapshot_controller.go
+++ b/poollet/volumepoollet/controllers/volumesnapshot_controller.go
@@ -55,6 +55,7 @@ type VolumeSnapshotReconciler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumesnapshots,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumesnapshots/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=storage.ironcore.dev,resources=volumesnapshots/finalizers,verbs=update


### PR DESCRIPTION
Recent k8s.io/* and controller-runtime versions wire up the new EventRecorder which writes to events.k8s.io/v1. Without this rule the apiserver rejects every event with:

  events.events.k8s.io "..." is forbidden: ... cannot patch
  resource "events" in API group "events.k8s.io"

Contributes to #1489 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event permissions to use the standard Kubernetes events API group, improving compatibility for event creation and updates.
  * Adjusted several access rules so related components have consistent permissions for secrets and events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->