### PR TITLE
`MachineScheduler` cache loses track of bound machines

### DIFF
--- a/internal/controllers/compute/machine_scheduler.go
+++ b/internal/controllers/compute/machine_scheduler.go
@@ -10,11 +10,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/ironcore/api/common/v1alpha1"
 	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
-	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	computeclient "github.com/ironcore-dev/ironcore/internal/client/compute"
 	"github.com/ironcore-dev/ironcore/internal/controllers/compute/scheduler"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
@@ -89,14 +87,8 @@ func (s *MachineScheduler) tolerateTaints(_ context.Context, pool *scheduler.Con
 }
 
 func (s *MachineScheduler) fitsPool(_ context.Context, pool *scheduler.ContainerInfo, machine *computev1alpha1.Machine) bool {
-	machineClassName := machine.Spec.MachineClassRef.Name
 
-	allocatable, ok := pool.Node().Status.Allocatable[corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClassName)]
-	if !ok {
-		return false
-	}
-
-	return allocatable.Cmp(*resource.NewQuantity(1, resource.DecimalSI)) >= 0
+	return pool.MaxAllocatable(machine.Spec.MachineClassRef.Name) > 0
 }
 
 func (s *MachineScheduler) reconcileExists(ctx context.Context, log logr.Logger, machine *computev1alpha1.Machine) (ctrl.Result, error) {
@@ -242,6 +234,14 @@ func (s *MachineScheduler) handleMachine() handler.EventHandler {
 
 			oldInstance := evt.ObjectOld.(*computev1alpha1.Machine)
 			newInstance := evt.ObjectNew.(*computev1alpha1.Machine)
+
+			if oldInstance.Spec.MachinePoolRef == nil && newInstance.Spec.MachinePoolRef != nil {
+				if err := s.Cache.AddInstance(newInstance); err != nil {
+					log.Error(err, "Error adding machine to cache")
+				}
+				return
+			}
+
 			if err := s.Cache.UpdateInstance(oldInstance, newInstance); err != nil {
 				log.Error(err, "Error updating machine in cache")
 			}

--- a/internal/controllers/compute/machine_scheduler_test.go
+++ b/internal/controllers/compute/machine_scheduler_test.go
@@ -49,7 +49,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image:           "my-image",
 				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
 			},
 		}
@@ -70,7 +69,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image:           "my-image",
 				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
 			},
 		}
@@ -148,7 +146,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachinePoolSelector: map[string]string{
 					"foo": "bar",
 				},
@@ -203,7 +200,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachineClassRef: corev1.LocalObjectReference{
 					Name: machineClass.Name,
 				},
@@ -302,7 +298,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachineClassRef: corev1.LocalObjectReference{
 					Name: machineClass.Name,
 				},
@@ -360,7 +355,6 @@ var _ = Describe("MachineScheduler", func() {
 					GenerateName: fmt.Sprintf("test-machine-%d-", i),
 				},
 				Spec: computev1alpha1.MachineSpec{
-					Image: "my-image",
 					MachineClassRef: corev1.LocalObjectReference{
 						Name: machineClass.Name,
 					},
@@ -409,7 +403,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachineClassRef: corev1.LocalObjectReference{
 					Name: machineClass.Name,
 				},
@@ -432,6 +425,75 @@ var _ = Describe("MachineScheduler", func() {
 		By("checking that the machine is scheduled onto the machine pool")
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: machinePool.Name})),
+		))
+	})
+
+	It("should correctly track cache state", func(ctx SpecContext) {
+		By("creating a machine pool")
+		machinePool := &computev1alpha1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-pool-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed(), "failed to create machine pool")
+
+		By("patching the machine pool status to contain capacity for 2 machines")
+		Eventually(UpdateStatus(machinePool, func() {
+			machinePool.Status.AvailableMachineClasses = []corev1.LocalObjectReference{{Name: machineClass.Name}}
+			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
+				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("2"),
+			}
+		})).Should(Succeed())
+
+		By("creating the first machine")
+		machine1 := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-machine-1-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine1)).To(Succeed(), "failed to create first machine")
+
+		By("waiting for the first machine to be scheduled")
+		Eventually(Object(machine1)).Should(SatisfyAll(
+			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: machinePool.Name})),
+		))
+
+		By("creating the second machine")
+		machine2 := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-machine-2-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine2)).To(Succeed(), "failed to create second machine")
+
+		By("waiting for the second machine to be scheduled")
+		Eventually(Object(machine2)).Should(SatisfyAll(
+			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: machinePool.Name})),
+		))
+
+		By("creating a third machine that should NOT be scheduled (capacity exhausted)")
+		machine3 := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-machine-3-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine3)).To(Succeed(), "failed to create third machine")
+
+		By("verifying the third machine remains unscheduled")
+		Consistently(Object(machine3)).Should(SatisfyAll(
+			HaveField("Spec.MachinePoolRef", BeNil()),
 		))
 	})
 
@@ -492,7 +554,6 @@ var _ = Describe("MachineScheduler", func() {
 				GenerateName: "test-machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachineClassRef: corev1.LocalObjectReference{
 					Name: secondMachineClass.Name,
 				},

--- a/internal/controllers/compute/scheduler/cache.go
+++ b/internal/controllers/compute/scheduler/cache.go
@@ -200,6 +200,9 @@ func (c *Cache) ForgetInstance(instance *v1alpha1.Machine) error {
 	}
 	log = log.WithValues("InstanceKey", key)
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	currState, ok := c.instanceStates[key]
 	if ok {
 		oldContainerKey := c.strategy.ContainerKey(currState.instance)
@@ -211,6 +214,7 @@ func (c *Cache) ForgetInstance(instance *v1alpha1.Machine) error {
 
 	if ok && c.assumedInstances.Has(key) {
 		c.removeInstance(log, key, instance)
+		return nil
 	}
 	return fmt.Errorf("instance %s(%v) wasn't assumed so cannot be forgotten", key, klog.KObj(instance))
 }
@@ -223,8 +227,8 @@ func (c *Cache) FinishBinding(instance *v1alpha1.Machine) error {
 	}
 	log = log.WithValues("InstanceKey", key)
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	log.V(5).Info("Finished binding for instance, can be expired")
 	currState, ok := c.instanceStates[key]

--- a/internal/controllers/storage/scheduler/cache.go
+++ b/internal/controllers/storage/scheduler/cache.go
@@ -201,6 +201,9 @@ func (c *Cache) ForgetInstance(instance *v1alpha1.Volume) error {
 	}
 	log = log.WithValues("InstanceKey", key)
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	currState, ok := c.instanceStates[key]
 	if ok {
 		oldContainerKey := c.strategy.ContainerKey(currState.instance)
@@ -212,6 +215,7 @@ func (c *Cache) ForgetInstance(instance *v1alpha1.Volume) error {
 
 	if ok && c.assumedInstances.Has(key) {
 		c.removeInstance(log, key, instance)
+		return nil
 	}
 	return fmt.Errorf("instance %s(%v) wasn't assumed so cannot be forgotten", key, klog.KObj(instance))
 }
@@ -224,8 +228,8 @@ func (c *Cache) FinishBinding(instance *v1alpha1.Volume) error {
 	}
 	log = log.WithValues("InstanceKey", key)
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	log.V(5).Info("Finished binding for instance, can be expired")
 	currState, ok := c.instanceStates[key]

--- a/internal/controllers/storage/volume_scheduler.go
+++ b/internal/controllers/storage/volume_scheduler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ironcore-dev/ironcore/api/common/v1alpha1"
-	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 	storagev1alpha1 "github.com/ironcore-dev/ironcore/api/storage/v1alpha1"
 	storageclient "github.com/ironcore-dev/ironcore/internal/client/storage"
 	"github.com/ironcore-dev/ironcore/internal/controllers/storage/scheduler"
@@ -95,14 +94,8 @@ func (s *VolumeScheduler) tolerateTaints(_ context.Context, pool *scheduler.Cont
 }
 
 func (s *VolumeScheduler) fitsPool(_ context.Context, pool *scheduler.ContainerInfo, volume *storagev1alpha1.Volume) bool {
-	volumeClassName := volume.Spec.VolumeClassRef.Name
-
-	allocatable, ok := pool.Node().Status.Allocatable[corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClassName)]
-	if !ok {
-		return false
-	}
-
-	return allocatable.Cmp(*volume.Spec.Resources.Storage()) >= 0
+	remaining := pool.MaxAllocatable(volume.Spec.VolumeClassRef.Name)
+	return remaining.Cmp(*volume.Spec.Resources.Storage()) >= 0
 }
 
 func (s *VolumeScheduler) updateSnapshot() {
@@ -249,6 +242,14 @@ func (s *VolumeScheduler) handleVolume() handler.EventHandler {
 
 			oldInstance := evt.ObjectOld.(*storagev1alpha1.Volume)
 			newInstance := evt.ObjectNew.(*storagev1alpha1.Volume)
+
+			if oldInstance.Spec.VolumePoolRef == nil && newInstance.Spec.VolumePoolRef != nil {
+				if err := s.Cache.AddInstance(newInstance); err != nil {
+					log.Error(err, "Error adding volume to cache")
+				}
+				return
+			}
+
 			if err := s.Cache.UpdateInstance(oldInstance, newInstance); err != nil {
 				log.Error(err, "Error updating volume in cache")
 			}

--- a/internal/controllers/storage/volume_scheduler_test.go
+++ b/internal/controllers/storage/volume_scheduler_test.go
@@ -464,4 +464,82 @@ var _ = Describe("VolumeScheduler", func() {
 			HaveField("Spec.VolumePoolRef", Equal(&corev1.LocalObjectReference{Name: volumePool.Name})),
 		))
 	})
+
+	It("should correctly track cache state", func(ctx SpecContext) {
+		By("creating a volume pool")
+		volumePool := &storagev1alpha1.VolumePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-pool-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, volumePool)).To(Succeed(), "failed to create volume pool")
+
+		By("patching the volume pool status to contain capacity for 2 volumes")
+		Eventually(UpdateStatus(volumePool, func() {
+			volumePool.Status.AvailableVolumeClasses = []corev1.LocalObjectReference{{Name: volumeClass.Name}}
+			volumePool.Status.Allocatable = corev1alpha1.ResourceList{
+				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name): resource.MustParse("2Gi"),
+			}
+		})).Should(Succeed())
+
+		By("creating the first volume")
+		volume1 := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-volume-1-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume1)).To(Succeed(), "failed to create first volume")
+
+		By("waiting for the first volume to be scheduled")
+		Eventually(Object(volume1)).Should(SatisfyAll(
+			HaveField("Spec.VolumePoolRef", Equal(&corev1.LocalObjectReference{Name: volumePool.Name})),
+		))
+
+		By("creating the second volume")
+		volume2 := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-volume-2-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume2)).To(Succeed(), "failed to create second volume")
+
+		By("waiting for the second volume to be scheduled")
+		Eventually(Object(volume2)).Should(SatisfyAll(
+			HaveField("Spec.VolumePoolRef", Equal(&corev1.LocalObjectReference{Name: volumePool.Name})),
+		))
+
+		By("creating a third volume that should NOT be scheduled (capacity exhausted)")
+		volume3 := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-volume-3-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume3)).To(Succeed(), "failed to create third volume")
+
+		By("verifying the third volume remains unscheduled")
+		Consistently(Object(volume3)).Should(SatisfyAll(
+			HaveField("Spec.VolumePoolRef", BeNil()),
+		))
+	})
 })


### PR DESCRIPTION
# Proposed Changes

- Fix `instance 5ebaf389-19c5-46dc-a108-6a99f18607c4 is not present in the cache and thus cannot be updated` error
- Fix missing `return nil` in `ForgetInstance` after successful removal.
- Use `MaxAllocatable()` in `fitsPool` to reject pools that are full.

Fixes #1491 