### PR TITLE
Remove the deprecated image field

### DIFF
--- a/api/compute/v1alpha1/machine_types.go
+++ b/api/compute/v1alpha1/machine_types.go
@@ -23,12 +23,6 @@ type MachineSpec struct {
 	// Power is the desired machine power state.
 	// Defaults to PowerOn.
 	Power Power `json:"power,omitempty"`
-	// Deprecated: Use LocalDisk to provide a bootable disk
-	// Image is the optional URL providing the operating system image of the machine.
-	// +optional
-	Image string `json:"image,omitempty"`
-	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
-	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecret,omitempty"`
 	// NetworkInterfaces define a list of network interfaces present on the machine
 	// +optional
 	// +patchMergeKey=name

--- a/api/compute/v1alpha1/util.go
+++ b/api/compute/v1alpha1/util.go
@@ -68,10 +68,6 @@ func MachineVolumeNames(machine *Machine) []string {
 func MachineSecretNames(machine *Machine) []string {
 	var names []string
 
-	if imagePullSecretRef := machine.Spec.ImagePullSecretRef; imagePullSecretRef != nil {
-		names = append(names, imagePullSecretRef.Name)
-	}
-
 	if ignitionRef := machine.Spec.IgnitionRef; ignitionRef != nil {
 		names = append(names, ignitionRef.Name)
 	}

--- a/api/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/api/compute/v1alpha1/zz_generated.deepcopy.go
@@ -514,11 +514,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
-	if in.ImagePullSecretRef != nil {
-		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
-		*out = new(v1.LocalObjectReference)
-		**out = **in
-	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]NetworkInterface, len(*in))

--- a/api/storage/v1alpha1/volume_types.go
+++ b/api/storage/v1alpha1/volume_types.go
@@ -31,11 +31,6 @@ type VolumeSpec struct {
 	ClaimRef *commonv1alpha1.LocalUIDReference `json:"claimRef,omitempty"`
 	// Resources is a description of the volume's resources and capacity.
 	Resources corev1alpha1.ResourceList `json:"resources,omitempty"`
-	// Image is an optional image to bootstrap the volume with.
-	// To be deprecated
-	Image string `json:"image,omitempty"`
-	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
-	ImagePullSecretRef *corev1.LocalObjectReference `json:"imagePullSecretRef,omitempty"`
 	// Unclaimable marks the volume as unclaimable.
 	Unclaimable bool `json:"unclaimable,omitempty"`
 	// Tolerations define tolerations the Volume has. Only any VolumePool whose taints
@@ -58,7 +53,6 @@ type VolumeDataSource struct {
 type OSDataSource struct {
 	// Image is an optional image to bootstrap the volume with.
 	Image string `json:"image,omitempty"`
-
 	// Architecture defines the architecture of the OS which should be used
 	Architecture *string `json:"architecture,omitempty"`
 }

--- a/api/storage/v1alpha1/zz_generated.deepcopy.go
+++ b/api/storage/v1alpha1/zz_generated.deepcopy.go
@@ -887,11 +887,6 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
-	if in.ImagePullSecretRef != nil {
-		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
-		*out = new(v1.LocalObjectReference)
-		**out = **in
-	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]commonv1alpha1.Toleration, len(*in))

--- a/broker/machinebroker/server/machine_create.go
+++ b/broker/machinebroker/server/machine_create.go
@@ -211,7 +211,6 @@ func (s *Server) createIronCoreMachine(
 			MachinePoolSelector: s.cluster.MachinePoolSelector(),
 			MachinePoolRef:      s.ironcoreMachinePoolRef(),
 			Power:               cfg.Power,
-			ImagePullSecretRef:  nil, // TODO: Specify as soon as available.
 			NetworkInterfaces:   ironcoreMachineNics,
 			Volumes:             ironcoreMachineVolumes,
 			IgnitionRef:         ignitionRef,

--- a/broker/volumebroker/server/volume.go
+++ b/broker/volumebroker/server/volume.go
@@ -42,7 +42,6 @@ func (s *Server) convertAggregateIronCoreVolume(volume *AggregateIronCoreVolume)
 	return &iri.Volume{
 		Metadata: metadata,
 		Spec: &iri.VolumeSpec{
-			Image:            volume.Volume.Spec.Image,
 			Class:            volume.Volume.Spec.VolumeClassRef.Name,
 			Resources:        resources,
 			Encryption:       s.convertIronCoreVolumeEncryption(volume),

--- a/broker/volumebroker/server/volume_create.go
+++ b/broker/volumebroker/server/volume_create.go
@@ -68,16 +68,13 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 	)
 	labels[volumepoolletv1alpha1.VolumeUIDLabel] = volume.GetMetadata().GetLabels()[volumepoolletv1alpha1.VolumeUIDLabel]
 
-	var image string
 	var volumeSnapshotRef *corev1.LocalObjectReference
 	var osImageDataSource *storagev1alpha1.OSDataSource
-	image = volume.Spec.Image // TODO: Remove this once volume.Spec.Image is deprecated
 
 	if dataSource := volume.Spec.VolumeDataSource; dataSource != nil {
 		switch {
 		case dataSource.SnapshotDataSource != nil:
 			volumeSnapshotRef = &corev1.LocalObjectReference{Name: dataSource.SnapshotDataSource.SnapshotId}
-			image = "" // TODO: Remove this once volume.Spec.Image is deprecated
 		case dataSource.ImageDataSource != nil:
 			var architecture *string
 			if dataSource.ImageDataSource.Architecture != "" {
@@ -88,7 +85,6 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 				Image:        dataSource.ImageDataSource.Image,
 				Architecture: architecture,
 			}
-			image = dataSource.ImageDataSource.Image
 		}
 	}
 
@@ -107,9 +103,7 @@ func (s *Server) getIronCoreVolumeConfig(_ context.Context, volume *iri.Volume) 
 			Resources: corev1alpha1.ResourceList{
 				corev1alpha1.ResourceStorage: *resource.NewQuantity(volume.Spec.Resources.StorageBytes, resource.DecimalSI),
 			},
-			Image:              image, // TODO: Remove this once volume.Spec.Image is deprecated
-			ImagePullSecretRef: nil,   // TODO: Fill if necessary
-			Encryption:         encryption,
+			Encryption: encryption,
 			DataSource: storagev1alpha1.VolumeDataSource{
 				VolumeSnapshotRef: volumeSnapshotRef,
 				OSImage:           osImageDataSource,

--- a/broker/volumebroker/server/volume_create_test.go
+++ b/broker/volumebroker/server/volume_create_test.go
@@ -112,7 +112,6 @@ var _ = Describe("CreateVolume", func() {
 				Image:        "test-image",
 				Architecture: ptr.To("amd64"),
 			}),
-			HaveField("Spec.Image", "test-image"),
 			HaveField("Spec.Resources", HaveLen(1)),
 		))
 	})

--- a/client-go/applyconfigurations/compute/v1alpha1/machinespec.go
+++ b/client-go/applyconfigurations/compute/v1alpha1/machinespec.go
@@ -26,11 +26,6 @@ type MachineSpecApplyConfiguration struct {
 	// Power is the desired machine power state.
 	// Defaults to PowerOn.
 	Power *computev1alpha1.Power `json:"power,omitempty"`
-	// Deprecated: Use LocalDisk to provide a bootable disk
-	// Image is the optional URL providing the operating system image of the machine.
-	Image *string `json:"image,omitempty"`
-	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
-	ImagePullSecretRef *v1.LocalObjectReference `json:"imagePullSecret,omitempty"`
 	// NetworkInterfaces define a list of network interfaces present on the machine
 	NetworkInterfaces []NetworkInterfaceApplyConfiguration `json:"networkInterfaces,omitempty"`
 	// Volumes are volumes attached to this machine.
@@ -88,22 +83,6 @@ func (b *MachineSpecApplyConfiguration) WithMachinePoolRef(value v1.LocalObjectR
 // If called multiple times, the Power field is set to the value of the last call.
 func (b *MachineSpecApplyConfiguration) WithPower(value computev1alpha1.Power) *MachineSpecApplyConfiguration {
 	b.Power = &value
-	return b
-}
-
-// WithImage sets the Image field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Image field is set to the value of the last call.
-func (b *MachineSpecApplyConfiguration) WithImage(value string) *MachineSpecApplyConfiguration {
-	b.Image = &value
-	return b
-}
-
-// WithImagePullSecretRef sets the ImagePullSecretRef field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ImagePullSecretRef field is set to the value of the last call.
-func (b *MachineSpecApplyConfiguration) WithImagePullSecretRef(value v1.LocalObjectReference) *MachineSpecApplyConfiguration {
-	b.ImagePullSecretRef = &value
 	return b
 }
 

--- a/client-go/applyconfigurations/storage/v1alpha1/volumespec.go
+++ b/client-go/applyconfigurations/storage/v1alpha1/volumespec.go
@@ -28,11 +28,6 @@ type VolumeSpecApplyConfiguration struct {
 	ClaimRef *commonv1alpha1.LocalUIDReference `json:"claimRef,omitempty"`
 	// Resources is a description of the volume's resources and capacity.
 	Resources *corev1alpha1.ResourceList `json:"resources,omitempty"`
-	// Image is an optional image to bootstrap the volume with.
-	// To be deprecated
-	Image *string `json:"image,omitempty"`
-	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
-	ImagePullSecretRef *v1.LocalObjectReference `json:"imagePullSecretRef,omitempty"`
 	// Unclaimable marks the volume as unclaimable.
 	Unclaimable *bool `json:"unclaimable,omitempty"`
 	// Tolerations define tolerations the Volume has. Only any VolumePool whose taints
@@ -93,22 +88,6 @@ func (b *VolumeSpecApplyConfiguration) WithClaimRef(value commonv1alpha1.LocalUI
 // If called multiple times, the Resources field is set to the value of the last call.
 func (b *VolumeSpecApplyConfiguration) WithResources(value corev1alpha1.ResourceList) *VolumeSpecApplyConfiguration {
 	b.Resources = &value
-	return b
-}
-
-// WithImage sets the Image field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Image field is set to the value of the last call.
-func (b *VolumeSpecApplyConfiguration) WithImage(value string) *VolumeSpecApplyConfiguration {
-	b.Image = &value
-	return b
-}
-
-// WithImagePullSecretRef sets the ImagePullSecretRef field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ImagePullSecretRef field is set to the value of the last call.
-func (b *VolumeSpecApplyConfiguration) WithImagePullSecretRef(value v1.LocalObjectReference) *VolumeSpecApplyConfiguration {
-	b.ImagePullSecretRef = &value
 	return b
 }
 

--- a/client-go/openapi/api_violations.report
+++ b/client-go/openapi/api_violations.report
@@ -46,7 +46,6 @@ API rule violation: list_type_missing,github.com/ironcore-dev/ironcore/api/stora
 API rule violation: list_type_missing,github.com/ironcore-dev/ironcore/api/storage/v1alpha1,VolumePoolStatus,Conditions
 API rule violation: list_type_missing,github.com/ironcore-dev/ironcore/api/storage/v1alpha1,VolumeSpec,Tolerations
 API rule violation: list_type_missing,github.com/ironcore-dev/ironcore/api/storage/v1alpha1,VolumeStatus,Conditions
-API rule violation: names_match,github.com/ironcore-dev/ironcore/api/compute/v1alpha1,MachineSpec,ImagePullSecretRef
 API rule violation: names_match,github.com/ironcore-dev/ironcore/api/networking/v1alpha1,LoadBalancerSpec,IPs
 API rule violation: names_match,github.com/ironcore-dev/ironcore/api/networking/v1alpha1,LoadBalancerStatus,IPs
 API rule violation: names_match,github.com/ironcore-dev/ironcore/api/networking/v1alpha1,NATGatewayStatus,IPs

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1558,19 +1558,6 @@ func schema_ironcore_api_compute_v1alpha1_MachineSpec(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
-					"image": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated: Use LocalDisk to provide a bootable disk Image is the optional URL providing the operating system image of the machine.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"imagePullSecret": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
-							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
-						},
-					},
 					"networkInterfaces": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -6247,19 +6234,6 @@ func schema_ironcore_api_storage_v1alpha1_VolumeSpec(ref common.ReferenceCallbac
 									},
 								},
 							},
-						},
-					},
-					"image": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Image is an optional image to bootstrap the volume with. To be deprecated",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"imagePullSecretRef": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
-							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
 						},
 					},
 					"unclaimable": {

--- a/config/samples/compute_v1alpha1_machine.yaml
+++ b/config/samples/compute_v1alpha1_machine.yaml
@@ -7,7 +7,6 @@ spec:
     name: machineclass-sample
   #  machinePoolRef:
   #    name: default
-  image: my-image
   volumes:
     - name: rootdisk # first disk is root disk
       # priority: 0 # optional

--- a/config/samples/e2e/bases/loadbalancer-public/machine1.yaml
+++ b/config/samples/e2e/bases/loadbalancer-public/machine1.yaml
@@ -35,6 +35,8 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image

--- a/config/samples/e2e/bases/loadbalancer-public/machine2.yaml
+++ b/config/samples/e2e/bases/loadbalancer-public/machine2.yaml
@@ -35,6 +35,8 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image

--- a/config/samples/e2e/bases/machine-with-ephemeral-resources/machine.yaml
+++ b/config/samples/e2e/bases/machine-with-ephemeral-resources/machine.yaml
@@ -32,6 +32,8 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image

--- a/config/samples/e2e/bases/machine-with-nonephemeral-resources/volume.yaml
+++ b/config/samples/e2e/bases/machine-with-nonephemeral-resources/volume.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   volumeClassRef:
     name: volumeclass-sample
-  image: gardenlinux:rootfs-image
   resources:
     storage: 10Gi
+  dataSource:
+    osImage:
+      image: gardenlinux:rootfs-image

--- a/config/samples/e2e/bases/network-peering/machine1.yaml
+++ b/config/samples/e2e/bases/network-peering/machine1.yaml
@@ -32,7 +32,9 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image
 

--- a/config/samples/e2e/bases/network-peering/machine2.yaml
+++ b/config/samples/e2e/bases/network-peering/machine2.yaml
@@ -32,7 +32,9 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image
 

--- a/config/samples/e2e/bases/network-policy/machine1.yaml
+++ b/config/samples/e2e/bases/network-policy/machine1.yaml
@@ -35,7 +35,9 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image
 

--- a/config/samples/e2e/bases/network-policy/machine2.yaml
+++ b/config/samples/e2e/bases/network-policy/machine2.yaml
@@ -35,7 +35,9 @@ spec:
         spec:
           volumeClassRef:
             name: volumeclass-sample
-          image: gardenlinux:rootfs-image
           resources:
             storage: 10Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-image
 

--- a/config/samples/e2e/loadbalancer-public/README.md
+++ b/config/samples/e2e/loadbalancer-public/README.md
@@ -38,9 +38,11 @@ spec:
             name: new-volumeClass
           volumePoolRef:
             name: new-volumePool
-          image: gardenlinux:rootfs-dev-20231025
           resources:
             storage: 15Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-dev-20231025
 ```
 
 5. Update the `kustomization.yaml` with below content

--- a/config/samples/e2e/machine-with-ephemeral-resources/README.md
+++ b/config/samples/e2e/machine-with-ephemeral-resources/README.md
@@ -36,9 +36,11 @@ spec:
             name: new-volumeClass
           volumePoolRef:
             name: new-volumePool
-          image: gardenlinux:rootfs-dev-20231025
           resources:
             storage: 15Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-dev-20231025
 ```
 
 5. Update the `kustomization.yaml` with below content

--- a/config/samples/e2e/machine-with-non-ephemeral-resources/README.md
+++ b/config/samples/e2e/machine-with-non-ephemeral-resources/README.md
@@ -39,9 +39,11 @@ metadata:
 spec:
   volumeClassRef:
     name: new-volumeClass
-  image: new-image:rootfs
   volumePoolRef:
     name: new-volumePool
+  dataSource:
+    osImage:
+      image: gardenlinux:rootfs-dev-20231025
 ```
 6. Update the `kustomization.yaml` with below content
 ```

--- a/config/samples/e2e/network-peering/README.md
+++ b/config/samples/e2e/network-peering/README.md
@@ -36,9 +36,11 @@ spec:
             name: new-volumeClass
           volumePoolRef:
             name: new-volumePool
-          image: gardenlinux:rootfs-dev-20231025
           resources:
             storage: 15Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-dev-20231025
 ```
 
 5. Update the `kustomization.yaml` with below content

--- a/config/samples/e2e/network-policy/README.md
+++ b/config/samples/e2e/network-policy/README.md
@@ -38,9 +38,11 @@ spec:
             name: new-volumeClass
           volumePoolRef:
             name: new-volumePool
-          image: gardenlinux:rootfs-dev-20231025
           resources:
             storage: 15Gi
+          dataSource:
+            osImage:
+              image: gardenlinux:rootfs-dev-20231025
 ```
 
 5. Update the `kustomization.yaml` with below content

--- a/config/samples/storage_v1alpha1_volume_restore_from_snapshot.yaml
+++ b/config/samples/storage_v1alpha1_volume_restore_from_snapshot.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.ironcore.dev/v1alpha1
 kind: Volume
 metadata:
-  name: volume-sample
+  name: restored-volume
 spec:
   volumeClassRef:
     name: volumeclass-sample
@@ -9,6 +9,6 @@ spec:
   #   name: volumepool-sample
   resources:
     storage: 100Gi
-  # dataSource:
-  #   osImage:
-  #     image: gardenlinux:rootfs-image
+  dataSource:
+    volumeSnapshotRef:
+      name: volume-snapshot-sample

--- a/docs/usage/compute/machine.md
+++ b/docs/usage/compute/machine.md
@@ -15,7 +15,6 @@ metadata:
 spec:
   machineClassRef:
     name: machineclass-sample
-  image: my-image
   volumes:
     - name: rootdisk # first disk is the root disk
       volumeRef:
@@ -33,7 +32,6 @@ spec:
 
 - machineClassRef (`string`): machineClassRef is a reference to the machine class/flavor of the machine.
 - machinePoolRef (`string`): machinePoolRef defines the machine pool to run the machine in. If empty, a scheduler will figure out an appropriate pool to run the machine in.
-- image (`string`): image is the optional URL providing the operating system image of the machine.
 - volumes (`list`): volumes are list volumes(storage) attached to this machine.
 - networkInterfaces (`list`): networkInterfaces define a list of network interfaces present on the machine
 - ignitionRef (`string`): ignitionRef is a reference to a `secret` containing the ignition YAML for the machine to boot up. If a key is empty, `DefaultIgnitionKey` will be used as a fallback. (`Note`: Refer to <a href="https://github.com/ironcore-dev/ironcore/tree/main/config/samples/e2e/bases/ignition">Sample Ignition</a> for creating ignition secret)
@@ -68,6 +66,6 @@ The `MachineScheduler` controller continuously watches for `Machines` without an
 A Machine can be in the following states:
 1. **Pending**:  A Machine is in a Pending state when the Machine has been accepted by the system, but not yet completely started. This includes time before being bound to a MachinePool, as well as time spent setting up the Machine on that MachinePool. 
 2. **Running**: A Machine in Running state when the machine is running on a MachinePool.
-2. **Shutdown**: A Machine is in a Shutdown state.
-3. **Terminating**: A Machine is Terminating.
-2. **Terminated**: A Machine is in the Terminated state when the machine has been permanently stopped and cannot be started.
+3. **Shutdown**: A Machine is in a Shutdown state.
+4. **Terminating**: A Machine is Terminating.
+5. **Terminated**: A Machine is in the Terminated state when the machine has been permanently stopped and cannot be started.

--- a/gen/swagger.json
+++ b/gen/swagger.json
@@ -71372,6 +71372,16 @@
 				}
 			}
 		},
+		"com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineGuestConfig": {
+			"description": "MachineGuestConfig contains guest OS level configuration for the machine.",
+			"type": "object",
+			"properties": {
+				"hostname": {
+					"description": "Hostname is the desired hostname of the machine.",
+					"type": "string"
+				}
+			}
+		},
 		"com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineList": {
 			"description": "MachineList contains a list of Machine",
 			"type": "object",
@@ -71617,17 +71627,13 @@
 					"x-kubernetes-patch-merge-key": "name",
 					"x-kubernetes-patch-strategy": "merge,retainKeys"
 				},
+				"guestConfig": {
+					"description": "GuestConfig contains guest OS level configuration for the machine.",
+					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineGuestConfig"
+				},
 				"ignitionRef": {
 					"description": "IgnitionRef is a reference to a secret containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
 					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.common.v1alpha1.SecretKeySelector"
-				},
-				"image": {
-					"description": "Deprecated: Use LocalDisk to provide a bootable disk Image is the optional URL providing the operating system image of the machine.",
-					"type": "string"
-				},
-				"imagePullSecret": {
-					"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
-					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
 				},
 				"machineClassRef": {
 					"description": "MachineClassRef is a reference to the machine class/flavor of the machine.",
@@ -74313,14 +74319,6 @@
 				"encryption": {
 					"description": "Encryption is an optional field which provides attributes to encrypt Volume.",
 					"$ref": "#/definitions/com.github.ironcore-dev.ironcore.api.storage.v1alpha1.VolumeEncryption"
-				},
-				"image": {
-					"description": "Image is an optional image to bootstrap the volume with. To be deprecated",
-					"type": "string"
-				},
-				"imagePullSecretRef": {
-					"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
-					"$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
 				},
 				"resources": {
 					"description": "Resources is a description of the volume's resources and capacity.",

--- a/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__compute.ironcore.dev__v1alpha1_openapi.json
@@ -4375,6 +4375,16 @@
 					}
 				}
 			},
+			"com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineGuestConfig": {
+				"description": "MachineGuestConfig contains guest OS level configuration for the machine.",
+				"type": "object",
+				"properties": {
+					"hostname": {
+						"description": "Hostname is the desired hostname of the machine.",
+						"type": "string"
+					}
+				}
+			},
 			"com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineList": {
 				"description": "MachineList contains a list of Machine",
 				"type": "object",
@@ -4701,23 +4711,19 @@
 						"x-kubernetes-patch-merge-key": "name",
 						"x-kubernetes-patch-strategy": "merge,retainKeys"
 					},
+					"guestConfig": {
+						"description": "GuestConfig contains guest OS level configuration for the machine.",
+						"allOf": [
+							{
+								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.compute.v1alpha1.MachineGuestConfig"
+							}
+						]
+					},
 					"ignitionRef": {
 						"description": "IgnitionRef is a reference to a secret containing the ignition YAML for the machine to boot up. If key is empty, DefaultIgnitionKey will be used as fallback.",
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.common.v1alpha1.SecretKeySelector"
-							}
-						]
-					},
-					"image": {
-						"description": "Deprecated: Use LocalDisk to provide a bootable disk Image is the optional URL providing the operating system image of the machine.",
-						"type": "string"
-					},
-					"imagePullSecret": {
-						"description": "ImagePullSecretRef is an optional secret for pulling the image of a machine.",
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
 							}
 						]
 					},
@@ -5414,18 +5420,6 @@
 						"allOf": [
 							{
 								"$ref": "#/components/schemas/com.github.ironcore-dev.ironcore.api.storage.v1alpha1.VolumeEncryption"
-							}
-						]
-					},
-					"image": {
-						"description": "Image is an optional image to bootstrap the volume with. To be deprecated",
-						"type": "string"
-					},
-					"imagePullSecretRef": {
-						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
 							}
 						]
 					},

--- a/gen/v3/apis__storage.ironcore.dev__v1alpha1_openapi.json
+++ b/gen/v3/apis__storage.ironcore.dev__v1alpha1_openapi.json
@@ -10627,18 +10627,6 @@
 							}
 						]
 					},
-					"image": {
-						"description": "Image is an optional image to bootstrap the volume with. To be deprecated",
-						"type": "string"
-					},
-					"imagePullSecretRef": {
-						"description": "ImagePullSecretRef is an optional secret for pulling the image of a volume.",
-						"allOf": [
-							{
-								"$ref": "#/components/schemas/io.k8s.api.core.v1.LocalObjectReference"
-							}
-						]
-					},
 					"resources": {
 						"description": "Resources is a description of the volume's resources and capacity.",
 						"type": "object",

--- a/internal/apis/compute/machine_types.go
+++ b/internal/apis/compute/machine_types.go
@@ -23,10 +23,6 @@ type MachineSpec struct {
 	// Power is the desired machine power state.
 	// Defaults to PowerOn.
 	Power Power
-	// Image is the optional URL providing the operating system image of the machine.
-	Image string
-	// ImagePullSecretRef is an optional secret for pulling the image of a machine.
-	ImagePullSecretRef *corev1.LocalObjectReference
 	// NetworkInterfaces define a list of network interfaces present on the machine
 	NetworkInterfaces []NetworkInterface
 	// Volumes are volumes attached to this machine.

--- a/internal/apis/compute/util.go
+++ b/internal/apis/compute/util.go
@@ -57,10 +57,6 @@ func MachineVolumeNames(machine *Machine) []string {
 func MachineSecretNames(machine *Machine) []string {
 	var names []string
 
-	if imagePullSecretRef := machine.Spec.ImagePullSecretRef; imagePullSecretRef != nil {
-		names = append(names, imagePullSecretRef.Name)
-	}
-
 	if ignitionRef := machine.Spec.IgnitionRef; ignitionRef != nil {
 		names = append(names, ignitionRef.Name)
 	}

--- a/internal/apis/compute/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/compute/v1alpha1/zz_generated.conversion.go
@@ -846,8 +846,6 @@ func autoConvert_v1alpha1_MachineSpec_To_compute_MachineSpec(in *computev1alpha1
 	out.MachinePoolSelector = *(*map[string]string)(unsafe.Pointer(&in.MachinePoolSelector))
 	out.MachinePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.MachinePoolRef))
 	out.Power = compute.Power(in.Power)
-	out.Image = in.Image
-	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]compute.NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
@@ -877,8 +875,6 @@ func autoConvert_compute_MachineSpec_To_v1alpha1_MachineSpec(in *compute.Machine
 	out.MachinePoolSelector = *(*map[string]string)(unsafe.Pointer(&in.MachinePoolSelector))
 	out.MachinePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.MachinePoolRef))
 	out.Power = computev1alpha1.Power(in.Power)
-	out.Image = in.Image
-	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.NetworkInterfaces = *(*[]computev1alpha1.NetworkInterface)(unsafe.Pointer(&in.NetworkInterfaces))
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes

--- a/internal/apis/compute/validation/machine.go
+++ b/internal/apis/compute/validation/machine.go
@@ -92,12 +92,6 @@ func validateMachineSpec(machineSpec *compute.MachineSpec, fldPath *field.Path) 
 		}
 	}
 
-	if machineSpec.ImagePullSecretRef != nil {
-		for _, msg := range apivalidation.NameIsDNSSubdomain(machineSpec.ImagePullSecretRef.Name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), machineSpec.ImagePullSecretRef.Name, msg))
-		}
-	}
-
 	seenNames := sets.NewString()
 	seenDevices := sets.NewString()
 	for i, vol := range machineSpec.Volumes {
@@ -308,7 +302,6 @@ func validateVolumeTemplateSpecForMachine(template *storage.VolumeTemplateSpec, 
 func validateMachineSpecUpdate(new, old *compute.MachineSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, ironcorevalidation.ValidateImmutableField(new.Image, old.Image, fldPath.Child("image"))...)
 	allErrs = append(allErrs, ironcorevalidation.ValidateImmutableField(new.MachineClassRef, old.MachineClassRef, fldPath.Child("machineClassRef"))...)
 	allErrs = append(allErrs, ironcorevalidation.ValidateSetOnceField(new.MachinePoolRef, old.MachinePoolRef, fldPath.Child("machinePoolRef"))...)
 

--- a/internal/apis/compute/validation/machine_test.go
+++ b/internal/apis/compute/validation/machine_test.go
@@ -194,16 +194,6 @@ var _ = Describe("Machine", func() {
 			},
 			ContainElement(InvalidField("spec.ignitionRef.name")),
 		),
-		Entry("invalid ignition ref name",
-			&compute.Machine{
-				Spec: compute.MachineSpec{
-					ImagePullSecretRef: &corev1.LocalObjectReference{
-						Name: "foo*",
-					},
-				},
-			},
-			ContainElement(InvalidField("spec.imagePullSecretRef.name")),
-		),
 	)
 
 	DescribeTable("ValidateMachineNetworkInterface",

--- a/internal/apis/compute/zz_generated.deepcopy.go
+++ b/internal/apis/compute/zz_generated.deepcopy.go
@@ -514,11 +514,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
-	if in.ImagePullSecretRef != nil {
-		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
-		*out = new(v1.LocalObjectReference)
-		**out = **in
-	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]NetworkInterface, len(*in))

--- a/internal/apis/storage/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/storage/v1alpha1/zz_generated.conversion.go
@@ -1161,8 +1161,6 @@ func autoConvert_v1alpha1_VolumeSpec_To_storage_VolumeSpec(in *storagev1alpha1.V
 	out.VolumePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumePoolRef))
 	out.ClaimRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.ClaimRef))
 	out.Resources = *(*core.ResourceList)(unsafe.Pointer(&in.Resources))
-	out.Image = in.Image
-	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.Unclaimable = in.Unclaimable
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.Encryption = (*storage.VolumeEncryption)(unsafe.Pointer(in.Encryption))
@@ -1183,8 +1181,6 @@ func autoConvert_storage_VolumeSpec_To_v1alpha1_VolumeSpec(in *storage.VolumeSpe
 	out.VolumePoolRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.VolumePoolRef))
 	out.ClaimRef = (*commonv1alpha1.LocalUIDReference)(unsafe.Pointer(in.ClaimRef))
 	out.Resources = *(*corev1alpha1.ResourceList)(unsafe.Pointer(&in.Resources))
-	out.Image = in.Image
-	out.ImagePullSecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.ImagePullSecretRef))
 	out.Unclaimable = in.Unclaimable
 	out.Tolerations = *(*[]commonv1alpha1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.Encryption = (*storagev1alpha1.VolumeEncryption)(unsafe.Pointer(in.Encryption))

--- a/internal/apis/storage/validation/volume.go
+++ b/internal/apis/storage/validation/volume.go
@@ -48,11 +48,6 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 			allErrs = append(allErrs, field.Required(fldPath.Child("resources").Key(string(core.ResourceStorage)), fmt.Sprintf("must specify %s", core.ResourceStorage)))
 		}
 
-		if spec.ImagePullSecretRef != nil {
-			for _, msg := range apivalidation.NameIsDNSSubdomain(spec.ImagePullSecretRef.Name, false) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("imagePullSecretRef").Child("name"), spec.ImagePullSecretRef.Name, msg))
-			}
-		}
 	} else {
 		if spec.VolumePoolSelector != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("volumePoolSelector"), "must not specify if volume class is empty"))
@@ -64,14 +59,6 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 
 		if spec.Resources != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("resources"), "must not specify if volume class is empty"))
-		}
-
-		if spec.Image != "" {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("image"), "must not specify if volume class is empty"))
-		}
-
-		if spec.ImagePullSecretRef != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("imagePullSecretRef"), "must not specify if volume class is empty"))
 		}
 
 		if spec.Tolerations != nil {

--- a/internal/apis/storage/validation/volume.go
+++ b/internal/apis/storage/validation/volume.go
@@ -66,7 +66,7 @@ func validateVolumeSpec(spec *storage.VolumeSpec, fldPath *field.Path) field.Err
 		}
 
 		if spec.DataSource.OSImage != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("osImage"), "must not specify if volume class is empty"))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("dataSource").Child("osImage"), "must not specify if volume class is empty"))
 		}
 	}
 

--- a/internal/apis/storage/validation/volume_test.go
+++ b/internal/apis/storage/validation/volume_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Volume", func() {
 					},
 				},
 			},
-			Not(ContainElement(ForbiddenField("spec.osImage"))),
+			Not(ContainElement(ForbiddenField("spec.dataSource.osImage"))),
 		),
 		Entry("classless: invalid os image as volume data source",
 			&storage.Volume{
@@ -158,7 +158,7 @@ var _ = Describe("Volume", func() {
 					},
 				},
 			},
-			ContainElement(ForbiddenField("spec.osImage")),
+			ContainElement(ForbiddenField("spec.dataSource.osImage")),
 		),
 		Entry("invalid os image as single volume data source",
 			&storage.Volume{
@@ -171,7 +171,7 @@ var _ = Describe("Volume", func() {
 					},
 				},
 			},
-			ContainElement(ForbiddenField("spec.osImage")),
+			ContainElement(ForbiddenField("spec.dataSource.osImage")),
 		),
 	)
 

--- a/internal/apis/storage/validation/volume_test.go
+++ b/internal/apis/storage/validation/volume_test.go
@@ -72,23 +72,7 @@ var _ = Describe("Volume", func() {
 			},
 			ContainElement(ForbiddenField("spec.claimRef")),
 		),
-		Entry("classless: image pull secret ref",
-			&storage.Volume{
-				Spec: storage.VolumeSpec{
-					ImagePullSecretRef: &corev1.LocalObjectReference{Name: "foo"},
-				},
-			},
-			ContainElement(ForbiddenField("spec.imagePullSecretRef")),
-		),
-		Entry("classful: invalid image pull secret ref name",
-			&storage.Volume{
-				Spec: storage.VolumeSpec{
-					VolumeClassRef:     &corev1.LocalObjectReference{Name: "foo"},
-					ImagePullSecretRef: &corev1.LocalObjectReference{Name: "foo*"},
-				},
-			},
-			ContainElement(InvalidField("spec.imagePullSecretRef.name")),
-		),
+
 		Entry("classless: no resources[storage]",
 			&storage.Volume{},
 			Not(ContainElement(RequiredField("spec.resources[storage]"))),

--- a/internal/apis/storage/volume_types.go
+++ b/internal/apis/storage/volume_types.go
@@ -30,11 +30,6 @@ type VolumeSpec struct {
 	ClaimRef *commonv1alpha1.LocalUIDReference
 	// Resources is a description of the volume's resources and capacity.
 	Resources core.ResourceList
-	// Image is an optional image to bootstrap the volume with.
-	// To be deprecated
-	Image string
-	// ImagePullSecretRef is an optional secret for pulling the image of a volume.
-	ImagePullSecretRef *corev1.LocalObjectReference
 	// Unclaimable marks the volume as unclaimable.
 	Unclaimable bool
 	// Tolerations define tolerations the Volume has. Only a VolumePool whose taints

--- a/internal/apis/storage/zz_generated.deepcopy.go
+++ b/internal/apis/storage/zz_generated.deepcopy.go
@@ -887,11 +887,6 @@ func (in *VolumeSpec) DeepCopyInto(out *VolumeSpec) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
-	if in.ImagePullSecretRef != nil {
-		in, out := &in.ImagePullSecretRef, &out.ImagePullSecretRef
-		*out = new(v1.LocalObjectReference)
-		**out = **in
-	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1alpha1.Toleration, len(*in))

--- a/internal/controllers/compute/machineclass_controller_test.go
+++ b/internal/controllers/compute/machineclass_controller_test.go
@@ -40,7 +40,6 @@ var _ = Describe("machineclass controller", func() {
 				GenerateName: "machine-",
 			},
 			Spec: computev1alpha1.MachineSpec{
-				Image: "my-image",
 				MachineClassRef: corev1.LocalObjectReference{
 					Name: machineClass.Name,
 				},

--- a/internal/registry/compute/machine/storage/tableconvertor.go
+++ b/internal/registry/compute/machine/storage/tableconvertor.go
@@ -52,11 +52,6 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 
 		cells = append(cells, name)
 		cells = append(cells, machine.Spec.MachineClassRef.Name)
-		if image := machine.Spec.Image; image != "" {
-			cells = append(cells, image)
-		} else {
-			cells = append(cells, "<none>")
-		}
 		if machinePoolRef := machine.Spec.MachinePoolRef; machinePoolRef != nil {
 			cells = append(cells, machinePoolRef.Name)
 		} else {

--- a/internal/registry/compute/machine/storage/tableconvertor.go
+++ b/internal/registry/compute/machine/storage/tableconvertor.go
@@ -32,6 +32,15 @@ func newTableConvertor() *convertor {
 	return &convertor{}
 }
 
+func volumeImage(machine *compute.Machine) string {
+	for _, volume := range machine.Spec.Volumes {
+		if volume.LocalDisk != nil && volume.LocalDisk.Image != "" {
+			return volume.LocalDisk.Image
+		}
+	}
+	return ""
+}
+
 func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	tab := &metav1.Table{
 		ColumnDefinitions: headers,
@@ -52,6 +61,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 
 		cells = append(cells, name)
 		cells = append(cells, machine.Spec.MachineClassRef.Name)
+		if image := volumeImage(machine); image != "" {
+			cells = append(cells, image)
+		} else {
+			cells = append(cells, "<none>")
+		}
 		if machinePoolRef := machine.Spec.MachinePoolRef; machinePoolRef != nil {
 			cells = append(cells, machinePoolRef.Name)
 		} else {

--- a/internal/registry/storage/volume/storage/tableconvertor.go
+++ b/internal/registry/storage/volume/storage/tableconvertor.go
@@ -56,6 +56,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 		} else {
 			cells = append(cells, "<none>")
 		}
+		if volume.Spec.DataSource.OSImage != nil && volume.Spec.DataSource.OSImage.Image != "" {
+			cells = append(cells, volume.Spec.DataSource.OSImage.Image)
+		} else {
+			cells = append(cells, "<none>")
+		}
 		if volumeClassRef := volume.Spec.VolumeClassRef; volumeClassRef != nil {
 			cells = append(cells, volumeClassRef.Name)
 		} else {

--- a/internal/registry/storage/volume/storage/tableconvertor.go
+++ b/internal/registry/storage/volume/storage/tableconvertor.go
@@ -56,11 +56,6 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 		} else {
 			cells = append(cells, "<none>")
 		}
-		if image := volume.Spec.Image; image != "" {
-			cells = append(cells, image)
-		} else {
-			cells = append(cells, "<none>")
-		}
 		if volumeClassRef := volume.Spec.VolumeClassRef; volumeClassRef != nil {
 			cells = append(cells, volumeClassRef.Name)
 		} else {

--- a/iri/apis/volume/v1alpha1/api.pb.go
+++ b/iri/apis/volume/v1alpha1/api.pb.go
@@ -2000,7 +2000,7 @@ const file_volume_v1alpha1_api_proto_rawDesc = "" +
 	"snapshotId\"\xb7\x01\n" +
 	"\x10VolumeDataSource\x12L\n" +
 	"\x11image_data_source\x18\x01 \x01(\v2 .volume.v1alpha1.ImageDataSourceR\x0fimageDataSource\x12U\n" +
-	"\x14snapshot_data_source\x18\x02 \x01(\v2#.volume.v1alpha1.SnapshotDataSourceR\x12snapshotDataSource\"\xf4\x01\n" +
+	"\x14snapshot_data_source\x18\x02 \x01(\v2#.volume.v1alpha1.SnapshotDataSourceR\x12snapshotDataSource\"\x81\x02\n" +
 	"\n" +
 	"VolumeSpec\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12>\n" +
@@ -2008,7 +2008,7 @@ const file_volume_v1alpha1_api_proto_rawDesc = "" +
 	"\n" +
 	"encryption\x18\x04 \x01(\v2\x1f.volume.v1alpha1.EncryptionSpecR\n" +
 	"encryption\x12O\n" +
-	"\x12volume_data_source\x18\x05 \x01(\v2!.volume.v1alpha1.VolumeDataSourceR\x10volumeDataSource\"\xb9\x01\n" +
+	"\x12volume_data_source\x18\x05 \x01(\v2!.volume.v1alpha1.VolumeDataSourceR\x10volumeDataSourceJ\x04\b\x01\x10\x02R\x05image\"\xb9\x01\n" +
 	"\fVolumeStatus\x122\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x1c.volume.v1alpha1.VolumeStateR\x05state\x125\n" +
 	"\x06access\x18\x02 \x01(\v2\x1d.volume.v1alpha1.VolumeAccessR\x06access\x12>\n" +

--- a/iri/apis/volume/v1alpha1/api.pb.go
+++ b/iri/apis/volume/v1alpha1/api.pb.go
@@ -480,7 +480,6 @@ func (x *VolumeDataSource) GetSnapshotDataSource() *SnapshotDataSource {
 
 type VolumeSpec struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	Image            string                 `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
 	Class            string                 `protobuf:"bytes,2,opt,name=class,proto3" json:"class,omitempty"`
 	Resources        *VolumeResources       `protobuf:"bytes,3,opt,name=resources,proto3" json:"resources,omitempty"`
 	Encryption       *EncryptionSpec        `protobuf:"bytes,4,opt,name=encryption,proto3" json:"encryption,omitempty"`
@@ -517,13 +516,6 @@ func (x *VolumeSpec) ProtoReflect() protoreflect.Message {
 // Deprecated: Use VolumeSpec.ProtoReflect.Descriptor instead.
 func (*VolumeSpec) Descriptor() ([]byte, []int) {
 	return file_volume_v1alpha1_api_proto_rawDescGZIP(), []int{7}
-}
-
-func (x *VolumeSpec) GetImage() string {
-	if x != nil {
-		return x.Image
-	}
-	return ""
 }
 
 func (x *VolumeSpec) GetClass() string {
@@ -2008,10 +2000,9 @@ const file_volume_v1alpha1_api_proto_rawDesc = "" +
 	"snapshotId\"\xb7\x01\n" +
 	"\x10VolumeDataSource\x12L\n" +
 	"\x11image_data_source\x18\x01 \x01(\v2 .volume.v1alpha1.ImageDataSourceR\x0fimageDataSource\x12U\n" +
-	"\x14snapshot_data_source\x18\x02 \x01(\v2#.volume.v1alpha1.SnapshotDataSourceR\x12snapshotDataSource\"\x8a\x02\n" +
+	"\x14snapshot_data_source\x18\x02 \x01(\v2#.volume.v1alpha1.SnapshotDataSourceR\x12snapshotDataSource\"\xf4\x01\n" +
 	"\n" +
 	"VolumeSpec\x12\x14\n" +
-	"\x05image\x18\x01 \x01(\tR\x05image\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12>\n" +
 	"\tresources\x18\x03 \x01(\v2 .volume.v1alpha1.VolumeResourcesR\tresources\x12?\n" +
 	"\n" +

--- a/iri/apis/volume/v1alpha1/api.proto
+++ b/iri/apis/volume/v1alpha1/api.proto
@@ -55,7 +55,6 @@ message VolumeDataSource {
 }
 
 message VolumeSpec {
-  string image = 1;
   string class = 2;
   VolumeResources resources = 3;
   EncryptionSpec encryption = 4;

--- a/iri/apis/volume/v1alpha1/api.proto
+++ b/iri/apis/volume/v1alpha1/api.proto
@@ -55,6 +55,8 @@ message VolumeDataSource {
 }
 
 message VolumeSpec {
+  reserved 1;
+  reserved "image";
   string class = 2;
   VolumeResources resources = 3;
   EncryptionSpec encryption = 4;

--- a/irictl-volume/tableconverters/volume.go
+++ b/irictl-volume/tableconverters/volume.go
@@ -29,7 +29,6 @@ var (
 			return api.Row{
 				volume.Metadata.Id,
 				volume.Spec.Class,
-				volume.Spec.Image,
 				volume.Status.State.String(),
 				duration.HumanDuration(time.Since(time.Unix(0, volume.Metadata.CreatedAt))),
 			}, nil

--- a/poollet/machinepoollet/controllers/machine_controller.go
+++ b/poollet/machinepoollet/controllers/machine_controller.go
@@ -338,10 +338,6 @@ func (r *MachineReconciler) create(
 		return ctrl.Result{}, nil
 	}
 
-	if machine.Spec.Image != "" { //nolint:staticcheck
-		r.Eventf(machine, nil, corev1.EventTypeWarning, "ImageRefDeprecated", "Image reference in %s is deprecated", machine.Spec.Image) //nolint:staticcheck
-	}
-
 	log.V(1).Info("Creating machine")
 	res, err := r.MachineRuntime.CreateMachine(ctx, &iri.CreateMachineRequest{
 		Machine: iriMachine,

--- a/poollet/volumepoollet/controllers/volume_controller.go
+++ b/poollet/volumepoollet/controllers/volume_controller.go
@@ -455,7 +455,6 @@ func (r *VolumeReconciler) prepareIRIVolume(ctx context.Context, log logr.Logger
 	return &iri.Volume{
 		Metadata: metadata,
 		Spec: &iri.VolumeSpec{
-			Image:            volume.Spec.Image,
 			Class:            class,
 			Resources:        resources,
 			Encryption:       encryption,

--- a/poollet/volumepoollet/controllers/volume_controller_test.go
+++ b/poollet/volumepoollet/controllers/volume_controller_test.go
@@ -66,7 +66,6 @@ var _ = Describe("VolumeController", func() {
 
 		_, iriVolume := GetSingleMapEntry(srv.Volumes)
 
-		Expect(iriVolume.Spec.Image).To(Equal(""))
 		Expect(iriVolume.Spec.Class).To(Equal(vc.Name))
 		Expect(iriVolume.Spec.Encryption).To(BeNil())
 		Expect(iriVolume.Spec.Resources.StorageBytes).To(Equal(size.Value()))
@@ -158,7 +157,6 @@ var _ = Describe("VolumeController", func() {
 
 		_, iriVolume := GetSingleMapEntry(srv.Volumes)
 
-		Expect(iriVolume.Spec.Image).To(Equal(""))
 		Expect(iriVolume.Spec.Class).To(Equal(vc.Name))
 		Expect(iriVolume.Spec.Resources.StorageBytes).To(Equal(size.Value()))
 		Expect(iriVolume.Spec.Encryption.SecretData).NotTo(HaveKeyWithValue(encryptionDataKey, encryptionData))
@@ -193,7 +191,6 @@ var _ = Describe("VolumeController", func() {
 
 		_, iriVolume := GetSingleMapEntry(srv.Volumes)
 
-		Expect(iriVolume.Spec.Image).To(Equal(""))
 		Expect(iriVolume.Spec.Class).To(Equal(expandableVc.Name))
 		Expect(iriVolume.Spec.Resources.StorageBytes).To(Equal(size.Value()))
 
@@ -984,7 +981,6 @@ var _ = Describe("VolumeController", func() {
 
 		_, iriVolume := GetSingleMapEntry(srv.Volumes)
 
-		Expect(iriVolume.Spec.Image).To(Equal(""))
 		Expect(iriVolume.Spec.Class).To(Equal(vc.Name))
 		Expect(iriVolume.Spec.Encryption).To(BeNil())
 		Expect(iriVolume.Spec.Resources.StorageBytes).To(Equal(size.Value()))


### PR DESCRIPTION
# Proposed Changes
- Remove the deprecated `image` and `imagePullSecretRef` field from `volumeSpec` and `machineSpec`

/ref #1495 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed legacy bootstrap `image` / `imagePullSecretRef` fields from Machine and Volume specs (including client builders and published schemas).
  * OS image selection and volume bootstrapping now rely on `dataSource.osImage.image` (and snapshot restores on `dataSource`).

* **Documentation**
  * Updated docs and samples to remove the legacy fields and use `dataSource.osImage.image`.

* **Tests / UI**
  * Updated tests and tables to stop asserting/rendering removed legacy `image` values.

* **New Features**
  * Added a sample for restoring a Volume from a snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->