### PR TITLE
Fix empty action field on IRI-mapped events

### DIFF
--- a/poollet/bucketpoollet/bem/bem.go
+++ b/poollet/bucketpoollet/bem/bem.go
@@ -53,12 +53,12 @@ func (m *BucketEventMapper) relist(ctx context.Context, log logr.Logger) error {
 					Namespace: bucketEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.BucketNamespaceLabel],
 				},
 			}
-			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
-			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
-			// API server.
+			// events.k8s.io/v1 requires a non-empty action field. Providers should populate
+			// Spec.Action on IRI events; fall back to "Unknown" so a forgotten value is
+			// obvious in the emitted event rather than silently dropped by the API server.
 			action := bucketEvent.Spec.Action
 			if action == "" {
-				action = bucketEvent.Spec.Reason
+				action = "Unknown"
 			}
 			m.Eventf(involvedBucket, nil, bucketEvent.Spec.Type, bucketEvent.Spec.Reason, action, bucketEvent.Spec.Message)
 		}

--- a/poollet/bucketpoollet/bem/bem.go
+++ b/poollet/bucketpoollet/bem/bem.go
@@ -53,7 +53,14 @@ func (m *BucketEventMapper) relist(ctx context.Context, log logr.Logger) error {
 					Namespace: bucketEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.BucketNamespaceLabel],
 				},
 			}
-			m.Eventf(involvedBucket, nil, bucketEvent.Spec.Type, bucketEvent.Spec.Reason, bucketEvent.Spec.Action, bucketEvent.Spec.Message)
+			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
+			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
+			// API server.
+			action := bucketEvent.Spec.Action
+			if action == "" {
+				action = bucketEvent.Spec.Reason
+			}
+			m.Eventf(involvedBucket, nil, bucketEvent.Spec.Type, bucketEvent.Spec.Reason, action, bucketEvent.Spec.Message)
 		}
 	}
 

--- a/poollet/bucketpoollet/bem/bem_test.go
+++ b/poollet/bucketpoollet/bem/bem_test.go
@@ -140,6 +140,61 @@ var _ = Describe("BucketEventMapper", func() {
 			HaveField("Action", Equal("Synced")),
 		)))
 	})
+
+	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+		By("creating a bucket")
+		bucket := &storagev1alpha1.Bucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "bucket-",
+			},
+			Spec: storagev1alpha1.BucketSpec{
+				BucketClassRef: &corev1.LocalObjectReference{Name: bc.Name},
+				BucketPoolRef:  &corev1.LocalObjectReference{Name: bp.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bucket)).To(Succeed())
+
+		By("waiting for the runtime to report the bucket")
+		Eventually(srv).Should(SatisfyAll(
+			HaveField("Buckets", HaveLen(1)),
+		))
+		_, iriBucket := GetSingleMapEntry(srv.Buckets)
+
+		By("setting an iri event with an empty action")
+		eventList := []*fakebucket.FakeEvent{{
+			Event: irievent.Event{
+				Spec: &irievent.EventSpec{
+					InvolvedObjectMeta: &v1alpha1.ObjectMetadata{
+						Labels: iriBucket.Metadata.Labels,
+					},
+					Reason:    "BucketReconcileFailed",
+					Message:   "reconcile failed",
+					Type:      "Warning",
+					Action:    "",
+					EventTime: time.Now().Unix(),
+				}},
+		},
+		}
+		srv.SetEvents(eventList)
+
+		By("validating the emitted event uses the reason as its action")
+		bucketEventList := &corev1.EventList{}
+		selectorField := fields.Set{}
+		selectorField["involvedObject.name"] = bucket.GetName()
+		Eventually(func(g Gomega) []corev1.Event {
+			err := k8sClient.List(ctx, bucketEventList,
+				client.InNamespace(ns.Name), client.MatchingFieldsSelector{Selector: selectorField.AsSelector()},
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			return bucketEventList.Items
+		}).Should(ContainElement(SatisfyAll(
+			HaveField("Reason", Equal("BucketReconcileFailed")),
+			HaveField("Message", Equal("reconcile failed")),
+			HaveField("Type", Equal(corev1.EventTypeWarning)),
+			HaveField("Action", Equal("BucketReconcileFailed")),
+		)))
+	})
 })
 
 func GetSingleMapEntry[K comparable, V any](m map[K]V) (K, V) {

--- a/poollet/bucketpoollet/bem/bem_test.go
+++ b/poollet/bucketpoollet/bem/bem_test.go
@@ -141,7 +141,7 @@ var _ = Describe("BucketEventMapper", func() {
 		)))
 	})
 
-	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+	It("should fall back to Unknown when the iri event has no action set", func(ctx SpecContext) {
 		By("creating a bucket")
 		bucket := &storagev1alpha1.Bucket{
 			ObjectMeta: metav1.ObjectMeta{
@@ -178,7 +178,7 @@ var _ = Describe("BucketEventMapper", func() {
 		}
 		srv.SetEvents(eventList)
 
-		By("validating the emitted event uses the reason as its action")
+		By("validating the emitted event has action set to Unknown")
 		bucketEventList := &corev1.EventList{}
 		selectorField := fields.Set{}
 		selectorField["involvedObject.name"] = bucket.GetName()
@@ -192,7 +192,7 @@ var _ = Describe("BucketEventMapper", func() {
 			HaveField("Reason", Equal("BucketReconcileFailed")),
 			HaveField("Message", Equal("reconcile failed")),
 			HaveField("Type", Equal(corev1.EventTypeWarning)),
-			HaveField("Action", Equal("BucketReconcileFailed")),
+			HaveField("Action", Equal("Unknown")),
 		)))
 	})
 })

--- a/poollet/machinepoollet/mem/mem.go
+++ b/poollet/machinepoollet/mem/mem.go
@@ -53,12 +53,12 @@ func (m *MachineEventMapper) relist(ctx context.Context, log logr.Logger) error 
 					Namespace: machineEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.MachineNamespaceLabel],
 				},
 			}
-			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
-			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
-			// API server.
+			// events.k8s.io/v1 requires a non-empty action field. Providers should populate
+			// Spec.Action on IRI events; fall back to "Unknown" so a forgotten value is
+			// obvious in the emitted event rather than silently dropped by the API server.
 			action := machineEvent.Spec.Action
 			if action == "" {
-				action = machineEvent.Spec.Reason
+				action = "Unknown"
 			}
 			m.Eventf(involvedMachine, nil, machineEvent.Spec.Type, machineEvent.Spec.Reason, action, machineEvent.Spec.Message)
 		}

--- a/poollet/machinepoollet/mem/mem.go
+++ b/poollet/machinepoollet/mem/mem.go
@@ -53,7 +53,14 @@ func (m *MachineEventMapper) relist(ctx context.Context, log logr.Logger) error 
 					Namespace: machineEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.MachineNamespaceLabel],
 				},
 			}
-			m.Eventf(involvedMachine, nil, machineEvent.Spec.Type, machineEvent.Spec.Reason, machineEvent.Spec.Action, machineEvent.Spec.Message)
+			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
+			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
+			// API server.
+			action := machineEvent.Spec.Action
+			if action == "" {
+				action = machineEvent.Spec.Reason
+			}
+			m.Eventf(involvedMachine, nil, machineEvent.Spec.Type, machineEvent.Spec.Reason, action, machineEvent.Spec.Message)
 		}
 	}
 

--- a/poollet/machinepoollet/mem/mem_test.go
+++ b/poollet/machinepoollet/mem/mem_test.go
@@ -154,6 +154,62 @@ var _ = Describe("MachineEventMapper", func() {
 			HaveField("Type", Equal(corev1.EventTypeNormal)),
 		)))
 	})
+
+	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+		By("creating a machine")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: mc.Name},
+				MachinePoolRef:  &corev1.LocalObjectReference{Name: mp.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, machine)
+
+		By("waiting for the runtime to report the machine")
+		Eventually(srv).Should(SatisfyAll(
+			HaveField("Machines", HaveLen(1)),
+		))
+		_, iriMachine := GetSingleMapEntry(srv.Machines)
+
+		By("setting an iri event with an empty action")
+		eventList := []*fakemachine.FakeEvent{{
+			Event: irievent.Event{
+				Spec: &irievent.EventSpec{
+					InvolvedObjectMeta: &v1alpha1.ObjectMetadata{
+						Labels: iriMachine.Metadata.Labels,
+					},
+					Reason:    "DomainDestroySucceeded",
+					Message:   "Domain destroyed",
+					Type:      "Warning",
+					Action:    "",
+					EventTime: time.Now().Unix(),
+				}},
+		},
+		}
+		srv.SetEvents(eventList)
+
+		By("validating the emitted event uses the reason as its action")
+		machineEventList := &corev1.EventList{}
+		selectorField := fields.Set{}
+		selectorField["involvedObject.name"] = machine.GetName()
+		Eventually(func(g Gomega) []corev1.Event {
+			err := k8sClient.List(ctx, machineEventList,
+				client.InNamespace(ns.Name), client.MatchingFieldsSelector{Selector: selectorField.AsSelector()},
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			return machineEventList.Items
+		}).Should(ContainElement(SatisfyAll(
+			HaveField("Reason", Equal("DomainDestroySucceeded")),
+			HaveField("Message", Equal("Domain destroyed")),
+			HaveField("Action", Equal("DomainDestroySucceeded")),
+			HaveField("Type", Equal(corev1.EventTypeWarning)),
+		)))
+	})
 })
 
 func GetSingleMapEntry[K comparable, V any](m map[K]V) (K, V) {

--- a/poollet/machinepoollet/mem/mem_test.go
+++ b/poollet/machinepoollet/mem/mem_test.go
@@ -155,7 +155,7 @@ var _ = Describe("MachineEventMapper", func() {
 		)))
 	})
 
-	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+	It("should fall back to Unknown when the iri event has no action set", func(ctx SpecContext) {
 		By("creating a machine")
 		machine := &computev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -193,7 +193,7 @@ var _ = Describe("MachineEventMapper", func() {
 		}
 		srv.SetEvents(eventList)
 
-		By("validating the emitted event uses the reason as its action")
+		By("validating the emitted event has action set to Unknown")
 		machineEventList := &corev1.EventList{}
 		selectorField := fields.Set{}
 		selectorField["involvedObject.name"] = machine.GetName()
@@ -206,7 +206,7 @@ var _ = Describe("MachineEventMapper", func() {
 		}).Should(ContainElement(SatisfyAll(
 			HaveField("Reason", Equal("DomainDestroySucceeded")),
 			HaveField("Message", Equal("Domain destroyed")),
-			HaveField("Action", Equal("DomainDestroySucceeded")),
+			HaveField("Action", Equal("Unknown")),
 			HaveField("Type", Equal(corev1.EventTypeWarning)),
 		)))
 	})

--- a/poollet/volumepoollet/vem/vem.go
+++ b/poollet/volumepoollet/vem/vem.go
@@ -54,7 +54,14 @@ func (m *VolumeEventMapper) relist(ctx context.Context, log logr.Logger) error {
 					Namespace: volumeEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.VolumeNamespaceLabel],
 				},
 			}
-			m.Eventf(involvedVolume, nil, volumeEvent.Spec.Type, volumeEvent.Spec.Reason, volumeEvent.Spec.Action, volumeEvent.Spec.Message)
+			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
+			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
+			// API server.
+			action := volumeEvent.Spec.Action
+			if action == "" {
+				action = volumeEvent.Spec.Reason
+			}
+			m.Eventf(involvedVolume, nil, volumeEvent.Spec.Type, volumeEvent.Spec.Reason, action, volumeEvent.Spec.Message)
 		}
 	}
 

--- a/poollet/volumepoollet/vem/vem.go
+++ b/poollet/volumepoollet/vem/vem.go
@@ -54,12 +54,12 @@ func (m *VolumeEventMapper) relist(ctx context.Context, log logr.Logger) error {
 					Namespace: volumeEvent.Spec.InvolvedObjectMeta.Labels[v1alpha1.VolumeNamespaceLabel],
 				},
 			}
-			// events.k8s.io/v1 requires a non-empty action field. Providers do not always populate
-			// Spec.Action on IRI events, so fall back to the reason to keep events acceptable to the
-			// API server.
+			// events.k8s.io/v1 requires a non-empty action field. Providers should populate
+			// Spec.Action on IRI events; fall back to "Unknown" so a forgotten value is
+			// obvious in the emitted event rather than silently dropped by the API server.
 			action := volumeEvent.Spec.Action
 			if action == "" {
-				action = volumeEvent.Spec.Reason
+				action = "Unknown"
 			}
 			m.Eventf(involvedVolume, nil, volumeEvent.Spec.Type, volumeEvent.Spec.Reason, action, volumeEvent.Spec.Message)
 		}

--- a/poollet/volumepoollet/vem/vem_test.go
+++ b/poollet/volumepoollet/vem/vem_test.go
@@ -152,6 +152,64 @@ var _ = Describe("VolumeEventMapper", func() {
 			HaveField("Type", Equal(corev1.EventTypeNormal)),
 		)))
 	})
+
+	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+		By("creating a volume")
+		volume := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "volume-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("250"),
+				},
+				VolumeClassRef: &corev1.LocalObjectReference{Name: vc.Name},
+				VolumePoolRef:  &corev1.LocalObjectReference{Name: vp.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volume)).To(Succeed(), "failed to create volume")
+
+		By("waiting for the runtime to report the volume")
+		Eventually(srv).Should(SatisfyAll(
+			HaveField("Volumes", HaveLen(1)),
+		))
+		_, iriVolume := GetSingleMapEntry(srv.Volumes)
+
+		By("setting an iri event with an empty action")
+		eventList := []*fakevolume.FakeEvent{{
+			Event: irievent.Event{
+				Spec: &irievent.EventSpec{
+					InvolvedObjectMeta: &v1alpha1.ObjectMetadata{
+						Labels: iriVolume.Metadata.Labels,
+					},
+					Reason:    "VolumeReconcileFailed",
+					Message:   "reconcile failed",
+					Type:      "Warning",
+					Action:    "",
+					EventTime: time.Now().Unix(),
+				}},
+		},
+		}
+		srv.SetEvents(eventList)
+
+		By("validating the emitted event uses the reason as its action")
+		volumeEventList := &corev1.EventList{}
+		selectorField := fields.Set{}
+		selectorField["involvedObject.name"] = volume.GetName()
+		Eventually(func(g Gomega) []corev1.Event {
+			err := k8sClient.List(ctx, volumeEventList,
+				client.InNamespace(ns.Name), client.MatchingFieldsSelector{Selector: selectorField.AsSelector()},
+			)
+			g.Expect(err).NotTo(HaveOccurred())
+			return volumeEventList.Items
+		}).Should(ContainElement(SatisfyAll(
+			HaveField("Reason", Equal("VolumeReconcileFailed")),
+			HaveField("Message", Equal("reconcile failed")),
+			HaveField("Action", Equal("VolumeReconcileFailed")),
+			HaveField("Type", Equal(corev1.EventTypeWarning)),
+		)))
+	})
 })
 
 func GetSingleMapEntry[K comparable, V any](m map[K]V) (K, V) {

--- a/poollet/volumepoollet/vem/vem_test.go
+++ b/poollet/volumepoollet/vem/vem_test.go
@@ -153,7 +153,7 @@ var _ = Describe("VolumeEventMapper", func() {
 		)))
 	})
 
-	It("should fall back to reason when the iri event has no action set", func(ctx SpecContext) {
+	It("should fall back to Unknown when the iri event has no action set", func(ctx SpecContext) {
 		By("creating a volume")
 		volume := &storagev1alpha1.Volume{
 			ObjectMeta: metav1.ObjectMeta{
@@ -193,7 +193,7 @@ var _ = Describe("VolumeEventMapper", func() {
 		}
 		srv.SetEvents(eventList)
 
-		By("validating the emitted event uses the reason as its action")
+		By("validating the emitted event has action set to Unknown")
 		volumeEventList := &corev1.EventList{}
 		selectorField := fields.Set{}
 		selectorField["involvedObject.name"] = volume.GetName()
@@ -206,7 +206,7 @@ var _ = Describe("VolumeEventMapper", func() {
 		}).Should(ContainElement(SatisfyAll(
 			HaveField("Reason", Equal("VolumeReconcileFailed")),
 			HaveField("Message", Equal("reconcile failed")),
-			HaveField("Action", Equal("VolumeReconcileFailed")),
+			HaveField("Action", Equal("Unknown")),
 			HaveField("Type", Equal(corev1.EventTypeWarning)),
 		)))
 	})


### PR DESCRIPTION
The events.k8s.io/v1 API server rejects events with an empty action field. Providers do not always populate Spec.Action on IRI events, causing the poollet event mappers to push invalid events. Fall back to Spec.Reason when Spec.Action is empty.

Additional changes will update provider-utils and providers to correctly send the action field.

Contributes to #1489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured emitted Kubernetes events always have a non-empty `action` value.
  * When the source event action is empty, Kubernetes event `action` now defaults to `Unknown`.
  * Applied consistently to bucket, machine, and volume event reporting.
  * Added automated tests confirming Kubernetes `Reason`, `Message`, and `Type` are preserved while `Action` is set to `Unknown` when the source action is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->