### PR TITLE
Fix networkplugin cert renewal RBAC

### DIFF
--- a/config/apiserver/rbac/networkplugin_role.yaml
+++ b/config/apiserver/rbac/networkplugin_role.yaml
@@ -8,3 +8,18 @@ rules:
   - apiGroups: ["core.apinet.ironcore.dev"]
     resources: ["networkinterfaces"]
     verbs: ["create","get", "update", "patch", "delete", "watch", "list"]
+  # Allow already-authenticated network plugins to request renewal of their
+  # own client certificate. The auto-approver
+  # (internal/controllers/core/certificate/networking/networkplugin.go) performs
+  # a SubjectAccessReview against the `networkpluginclient` subresource, so both
+  # the base resource create and the subresource create must be granted here.
+  # Without this, only the initial bootstrap (via the bootstrapper role bound to
+  # the bootstrap-token group) works, and cert rotation fails once the plugin
+  # has switched from its bootstrap kubeconfig to its issued client cert.
+  # Mirrors the machinepool / volumepool / bucketpool roles.
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests/networkpluginclient"]
+    verbs: ["create"]


### PR DESCRIPTION
Fixes #1508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded network plugin permissions to support creating and retrieving certificate signing requests.
  * Enabled the client certificate renewal flow to proceed successfully, improving reliability of certificate-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->