### PR TITLE
Harmonize `iri-remote` and update `WellKnownEndpoints`

### DIFF
--- a/iri/remote/bucket/bucket.go
+++ b/iri/remote/bucket/bucket.go
@@ -5,11 +5,9 @@ package bucket
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/ironcore-dev/ironcore/iri/remote/common"
 )
 
 const (
@@ -18,36 +16,13 @@ const (
 
 var WellKnownEndpoints = []string{
 	"/var/run/iri-bucketbroker.sock",
-	"/var/run/iri-cephd.sock",
+	"/var/run/iri-bucketprovider.sock",
 }
 
 func GetAddressWithTimeout(timeout time.Duration, explicitAddress string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return GetAddress(ctx, explicitAddress)
+	return common.GetAddressWithTimeout(timeout, explicitAddress, AddressEnv, WellKnownEndpoints)
 }
 
 func GetAddress(ctx context.Context, explicitAddress string) (string, error) {
-	if explicitAddress != "" {
-		return explicitAddress, nil
-	}
-
-	if address := os.Getenv(AddressEnv); address != "" {
-		return address, nil
-	}
-
-	var endpoint string
-	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		for _, wellKnownEndpoint := range WellKnownEndpoints {
-			if stat, err := os.Stat(wellKnownEndpoint); err == nil && stat.Mode().Type()&os.ModeSocket != 0 {
-				endpoint = wellKnownEndpoint
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		return "", fmt.Errorf("could not determine which enpdoint to use")
-	}
-
-	return fmt.Sprintf("unix://%s", endpoint), nil
+	return common.GetAddress(ctx, explicitAddress, AddressEnv, WellKnownEndpoints)
 }

--- a/iri/remote/common/address.go
+++ b/iri/remote/common/address.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func GetAddressWithTimeout(timeout time.Duration, explicitAddress string, addressEnv string, wellKnownEndpoints []string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return GetAddress(ctx, explicitAddress, addressEnv, wellKnownEndpoints)
+}
+
+func GetAddress(ctx context.Context, explicitAddress string, addressEnv string, wellKnownEndpoints []string) (string, error) {
+	if explicitAddress != "" {
+		return explicitAddress, nil
+	}
+
+	if address := os.Getenv(addressEnv); address != "" {
+		return address, nil
+	}
+
+	var endpoint string
+	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		for _, wellKnownEndpoint := range wellKnownEndpoints {
+			if stat, err := os.Stat(wellKnownEndpoint); err == nil && stat.Mode().Type()&os.ModeSocket != 0 {
+				endpoint = wellKnownEndpoint
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		return "", fmt.Errorf("could not determine which endpoint to use")
+	}
+
+	return fmt.Sprintf("unix://%s", endpoint), nil
+}

--- a/iri/remote/machine/machine.go
+++ b/iri/remote/machine/machine.go
@@ -5,11 +5,9 @@ package machine
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/ironcore-dev/ironcore/iri/remote/common"
 )
 
 const (
@@ -18,36 +16,13 @@ const (
 
 var WellKnownEndpoints = []string{
 	"/var/run/iri-machinebroker.sock",
-	"/var/run/iri-virtd.sock",
+	"/var/run/iri-machineprovider.sock",
 }
 
 func GetAddressWithTimeout(timeout time.Duration, explicitAddress string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return GetAddress(ctx, explicitAddress)
+	return common.GetAddressWithTimeout(timeout, explicitAddress, AddressEnv, WellKnownEndpoints)
 }
 
 func GetAddress(ctx context.Context, explicitAddress string) (string, error) {
-	if explicitAddress != "" {
-		return explicitAddress, nil
-	}
-
-	if address := os.Getenv(AddressEnv); address != "" {
-		return address, nil
-	}
-
-	var endpoint string
-	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		for _, wellKnownEndpoint := range WellKnownEndpoints {
-			if stat, err := os.Stat(wellKnownEndpoint); err == nil && stat.Mode().Type()&os.ModeSocket != 0 {
-				endpoint = wellKnownEndpoint
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		return "", fmt.Errorf("could not determine which enpdoint to use")
-	}
-
-	return fmt.Sprintf("unix://%s", endpoint), nil
+	return common.GetAddress(ctx, explicitAddress, AddressEnv, WellKnownEndpoints)
 }

--- a/iri/remote/volume/volume.go
+++ b/iri/remote/volume/volume.go
@@ -5,11 +5,9 @@ package volume
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/ironcore-dev/ironcore/iri/remote/common"
 )
 
 const (
@@ -18,36 +16,13 @@ const (
 
 var WellKnownEndpoints = []string{
 	"/var/run/iri-volumebroker.sock",
-	"/var/run/iri-cephd.sock",
+	"/var/run/iri-volumeprovider.sock",
 }
 
 func GetAddressWithTimeout(timeout time.Duration, explicitAddress string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return GetAddress(ctx, explicitAddress)
+	return common.GetAddressWithTimeout(timeout, explicitAddress, AddressEnv, WellKnownEndpoints)
 }
 
 func GetAddress(ctx context.Context, explicitAddress string) (string, error) {
-	if explicitAddress != "" {
-		return explicitAddress, nil
-	}
-
-	if address := os.Getenv(AddressEnv); address != "" {
-		return address, nil
-	}
-
-	var endpoint string
-	if err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		for _, wellKnownEndpoint := range WellKnownEndpoints {
-			if stat, err := os.Stat(wellKnownEndpoint); err == nil && stat.Mode().Type()&os.ModeSocket != 0 {
-				endpoint = wellKnownEndpoint
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		return "", fmt.Errorf("could not determine which enpdoint to use")
-	}
-
-	return fmt.Sprintf("unix://%s", endpoint), nil
+	return common.GetAddress(ctx, explicitAddress, AddressEnv, WellKnownEndpoints)
 }


### PR DESCRIPTION
# Proposed Changes

- Harmonized `iri-remote` and updated `WellKnownEndpoints`
- This allows to use `WellKnownEndpoints` to prevent initial pod restart if socket is not there 

Fixes: #1516
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized runtime endpoint discovery across bucket, machine, and volume services.
  - Services can now consistently select configured endpoints, environment-provided endpoints, or available local sockets.
  - Updated supported local socket paths for machine and volume services.
  - Removed an obsolete bucket socket endpoint from automatic discovery.
  - Improved timeout handling when no suitable endpoint is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->