### PR TITLE
Add MachineEvictionController

### DIFF
--- a/cmd/ironcore-controller-manager/main.go
+++ b/cmd/ironcore-controller-manager/main.go
@@ -147,6 +147,7 @@ func main() {
 		machineEphemeralNetworkInterfaceController,
 		machineEphemeralVolumeController,
 		machineSchedulerController,
+		machineEvictionController,
 		machineClassController,
 		machinePoolLifecycleController,
 


### PR DESCRIPTION
So far it was never enabled.

Contributes to #1510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Machine Eviction controller to the set of controllers that can be enabled through the `--controllers` option.
  * The controller is now included when selecting all available controllers or choosing from the predefined controller set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->