### PR TITLE
Fix allocatable calculation in poollets

### DIFF
--- a/poollet/machinepoollet/controllers/machinepool_controller.go
+++ b/poollet/machinepoollet/controllers/machinepool_controller.go
@@ -121,6 +121,7 @@ func (r *MachinePoolReconciler) calculateCapacity(
 	}
 
 	usedResources := corev1alpha1.ResourceList{}
+	newQuantity := resource.MustParse("1")
 	for _, machine := range machines {
 		className := machine.Spec.MachineClassRef.Name
 		res, ok := usedResources[corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, className)]
@@ -129,7 +130,8 @@ func (r *MachinePoolReconciler) calculateCapacity(
 			continue
 		}
 
-		res.Add(resource.MustParse("1"))
+		res.Add(newQuantity)
+		usedResources[corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, className)] = res
 	}
 
 	return capacity, quota.SubtractWithNonNegativeResult(capacity, usedResources), supported, nil

--- a/poollet/machinepoollet/controllers/machinepool_controller_test.go
+++ b/poollet/machinepoollet/controllers/machinepool_controller_test.go
@@ -107,7 +107,35 @@ var _ = Describe("MachinePoolController", func() {
 			})),
 		))
 
-		By("creating a second machine")
+		By("creating a second machine of same class")
+		machine_sameclass := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-machine-sameclass",
+				Namespace:    ns.Name,
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{
+					Name: machineClass2.Name,
+				},
+				MachinePoolRef: &corev1.LocalObjectReference{
+					Name: machinePool.Name,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine_sameclass)).To(Succeed(), "failed to create machine")
+		DeferCleanup(k8sClient.Delete, machine_sameclass)
+
+		By("checking if the allocatable resources are correct")
+		Eventually(Object(machinePool)).Should(SatisfyAll(
+			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
+				return quota.Contains(allocatable, corev1alpha1.ResourceList{
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):  *resource.NewQuantity(machineClassCapacity, resource.DecimalSI),
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity-2, resource.DecimalSI),
+				})
+			})),
+		))
+
+		By("creating a machine with second machineclass")
 		machine2 := &computev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-machine",
@@ -130,7 +158,7 @@ var _ = Describe("MachinePoolController", func() {
 			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
 				return quota.Contains(allocatable, corev1alpha1.ResourceList{
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):  *resource.NewQuantity(machineClassCapacity-1, resource.DecimalSI),
-					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity-1, resource.DecimalSI),
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass2.Name): *resource.NewQuantity(machineClass2Capacity-2, resource.DecimalSI),
 				})
 			})),
 		))

--- a/poollet/volumepoollet/controllers/volumepool_controller.go
+++ b/poollet/volumepoollet/controllers/volumepool_controller.go
@@ -110,6 +110,7 @@ func (r *VolumePoolReconciler) calculateCapacity(
 		}
 
 		res.Add(*volume.Spec.Resources.Storage())
+		usedResources[corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, className)] = res
 	}
 
 	return capacity, quota.SubtractWithNonNegativeResult(capacity, usedResources), supported, nil

--- a/poollet/volumepoollet/controllers/volumepool_controller_test.go
+++ b/poollet/volumepoollet/controllers/volumepool_controller_test.go
@@ -247,7 +247,7 @@ var _ = Describe("VolumePoolController", func() {
 				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
 				VolumePoolRef:  &corev1.LocalObjectReference{Name: volumePool.Name},
 				Resources: corev1alpha1.ResourceList{
-					corev1alpha1.ResourceStorage: resource.MustParse("10Gi"),
+					corev1alpha1.ResourceStorage: resource.MustParse("5Gi"),
 				},
 			},
 		}
@@ -258,7 +258,34 @@ var _ = Describe("VolumePoolController", func() {
 		Eventually(Object(volumePool)).Should(SatisfyAll(
 			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
 				return quota.Equals(allocatable, corev1alpha1.ResourceList{
-					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name):           resource.MustParse("2Gi"),
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name):           resource.MustParse("7Gi"),
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, expandableVolumeClass.Name): expandableVolumeClassCapacity,
+				})
+			})),
+		))
+
+		By("creating second volume of same class")
+		volumeSameClass := &storagev1alpha1.Volume{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "volume-same-class-",
+			},
+			Spec: storagev1alpha1.VolumeSpec{
+				VolumeClassRef: &corev1.LocalObjectReference{Name: volumeClass.Name},
+				VolumePoolRef:  &corev1.LocalObjectReference{Name: volumePool.Name},
+				Resources: corev1alpha1.ResourceList{
+					corev1alpha1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, volumeSameClass)).To(Succeed(), "failed to create volume")
+		DeferCleanup(expectVolumeDeleted, volumeSameClass)
+
+		By("checking if the allocatable resources are correct")
+		Eventually(Object(volumePool)).Should(SatisfyAll(
+			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
+				return quota.Equals(allocatable, corev1alpha1.ResourceList{
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name):           resource.MustParse("5Gi"),
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, expandableVolumeClass.Name): expandableVolumeClassCapacity,
 				})
 			})),
@@ -285,7 +312,7 @@ var _ = Describe("VolumePoolController", func() {
 		Eventually(Object(volumePool)).Should(SatisfyAll(
 			HaveField("Status.Allocatable", Satisfy(func(allocatable corev1alpha1.ResourceList) bool {
 				return quota.Equals(allocatable, corev1alpha1.ResourceList{
-					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name):           resource.MustParse("2Gi"),
+					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, volumeClass.Name):           resource.MustParse("5Gi"),
 					corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeVolumeClass, expandableVolumeClass.Name): resource.MustParse("40Gi"),
 				})
 			})),


### PR DESCRIPTION
# Proposed Changes

- Correct allocatable calculation for MachinPool and VolumePool
- Add test case to cover the scenarion


Fixes #1528 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected machine pool capacity/allocatable calculations when multiple machines share the same machine class.
  * Fixed volume pool capacity/allocatable calculations by ensuring used storage increments persist correctly for quota updates.
* **Tests**
  * Expanded capacity tests to cover multiple machines and intermediate allocatable expectations for shared classes.
  * Updated volume capacity test scenarios and expected allocatable storage values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->