### PR TITLE
Enhance scheduling to respect `MachinePool` `Ready` condition

### DIFF
--- a/internal/controllers/compute/machine_scheduler.go
+++ b/internal/controllers/compute/machine_scheduler.go
@@ -82,12 +82,17 @@ func (s *MachineScheduler) matchesLabels(_ context.Context, pool *scheduler.Cont
 	return machinePoolSelector.Matches(nodeLabels)
 }
 
+func (s *MachineScheduler) poolReady(_ context.Context, pool *scheduler.ContainerInfo) bool {
+	cond := computev1alpha1.FindMachinePoolCondition(pool.Node().Status.Conditions, computev1alpha1.MachinePoolReady)
+
+	return cond != nil && cond.Status == corev1.ConditionTrue
+}
+
 func (s *MachineScheduler) tolerateTaints(_ context.Context, pool *scheduler.ContainerInfo, machine *computev1alpha1.Machine) bool {
 	return v1alpha1.TolerateTaints(machine.Spec.Tolerations, pool.Node().Spec.Taints)
 }
 
 func (s *MachineScheduler) fitsPool(_ context.Context, pool *scheduler.ContainerInfo, machine *computev1alpha1.Machine) bool {
-
 	return pool.MaxAllocatable(machine.Spec.MachineClassRef.Name) > 0
 }
 
@@ -102,6 +107,10 @@ func (s *MachineScheduler) reconcileExists(ctx context.Context, log logr.Logger,
 
 	var filteredNodes []*scheduler.ContainerInfo
 	for _, node := range nodes {
+		if !s.poolReady(ctx, node) {
+			log.Info("node filtered", "reason", "pool not ready")
+			continue
+		}
 		if !s.tolerateTaints(ctx, node, machine) {
 			log.Info("node filtered", "reason", "taints do not match")
 			continue

--- a/internal/controllers/compute/machine_scheduler_test.go
+++ b/internal/controllers/compute/machine_scheduler_test.go
@@ -594,7 +594,7 @@ var _ = Describe("MachineScheduler", func() {
 		))
 	})
 
-	It("should not schedule machines onto a machine pool that is not ready", func(ctx SpecContext) {
+	It("should not schedule machines onto a machine pool without ready condition", func(ctx SpecContext) {
 		By("creating a machine pool")
 		machinePool := &computev1alpha1.MachinePool{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/compute/machine_scheduler_test.go
+++ b/internal/controllers/compute/machine_scheduler_test.go
@@ -21,11 +21,11 @@ import (
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 )
 
-func markMachinePoolReady(machinePool *computev1alpha1.MachinePool) {
+func setMachinePoolReady(machinePool *computev1alpha1.MachinePool, status corev1.ConditionStatus) {
 	machinePool.Status.Conditions = computev1alpha1.SetMachinePoolCondition(machinePool.Status.Conditions,
 		computev1alpha1.MachinePoolCondition{
 			Type:   computev1alpha1.MachinePoolReady,
-			Status: corev1.ConditionTrue,
+			Status: status,
 		})
 }
 
@@ -48,7 +48,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine w/ the requested machine class")
@@ -103,7 +103,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("waiting for the machine to be scheduled onto the machine pool")
@@ -128,7 +128,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePoolNoMatchingLabels.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePoolNoMatchingLabels)
+			setMachinePoolReady(machinePoolNoMatchingLabels, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine pool w/ matching labels")
@@ -148,7 +148,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePoolMatchingLabels.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePoolMatchingLabels)
+			setMachinePoolReady(machinePoolMatchingLabels, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine w/ the requested machine class")
@@ -203,7 +203,7 @@ var _ = Describe("MachineScheduler", func() {
 			taintedMachinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(taintedMachinePool)
+			setMachinePoolReady(taintedMachinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -251,7 +251,7 @@ var _ = Describe("MachineScheduler", func() {
 
 		By("re-asserting the machine pool is ready")
 		Eventually(UpdateStatus(taintedMachinePool, func() {
-			markMachinePoolReady(taintedMachinePool)
+			setMachinePoolReady(taintedMachinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("observing the machine is scheduled onto the machine pool")
@@ -275,7 +275,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -308,7 +308,7 @@ var _ = Describe("MachineScheduler", func() {
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):       resource.MustParse("5"),
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, secondMachineClass.Name): resource.MustParse("100"),
 			}
-			markMachinePoolReady(secondMachinePool)
+			setMachinePoolReady(secondMachinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -346,7 +346,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("50"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -365,7 +365,7 @@ var _ = Describe("MachineScheduler", func() {
 			secondMachinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("50"),
 			}
-			markMachinePoolReady(secondMachinePool)
+			setMachinePoolReady(secondMachinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating machines")
@@ -416,7 +416,7 @@ var _ = Describe("MachineScheduler", func() {
 		By("patching the machine pool status to contain a machine class")
 		Eventually(UpdateStatus(machinePool, func() {
 			machinePool.Status.AvailableMachineClasses = []corev1.LocalObjectReference{{Name: machineClass.Name}}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -443,7 +443,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("checking that the machine is scheduled onto the machine pool")
@@ -467,7 +467,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("2"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating the first machine")
@@ -537,7 +537,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("5"),
 			}
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -571,7 +571,7 @@ var _ = Describe("MachineScheduler", func() {
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):       resource.MustParse("5"),
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, secondMachineClass.Name): resource.MustParse("5"),
 			}
-			markMachinePoolReady(secondMachinePool)
+			setMachinePoolReady(secondMachinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -628,7 +628,52 @@ var _ = Describe("MachineScheduler", func() {
 
 		By("marking the machine pool ready")
 		Eventually(UpdateStatus(machinePool, func() {
-			markMachinePoolReady(machinePool)
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
+		})).Should(Succeed())
+
+		By("waiting for the machine to be scheduled once the pool is ready")
+		Eventually(Object(machine)).Should(SatisfyAll(
+			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: machinePool.Name})),
+			HaveField("Status.State", Equal(computev1alpha1.MachineStatePending)),
+		))
+	})
+
+	It("should not schedule machines onto a machine pool whose ready condition is false", func(ctx SpecContext) {
+		By("creating a machine pool")
+		machinePool := &computev1alpha1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-pool-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed(), "failed to create machine pool")
+
+		By("patching the machine pool status to have capacity but a ready condition of false")
+		Eventually(UpdateStatus(machinePool, func() {
+			machinePool.Status.AvailableMachineClasses = []corev1.LocalObjectReference{{Name: machineClass.Name}}
+			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
+				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
+			}
+			setMachinePoolReady(machinePool, corev1.ConditionFalse)
+		})).Should(Succeed())
+
+		By("creating a machine w/ the requested machine class")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "failed to create machine")
+
+		By("observing the machine isn't scheduled onto the not-ready machine pool")
+		Consistently(Object(machine)).Should(HaveField("Spec.MachinePoolRef", BeNil()))
+
+		By("marking the machine pool ready")
+		Eventually(UpdateStatus(machinePool, func() {
+			setMachinePoolReady(machinePool, corev1.ConditionTrue)
 		})).Should(Succeed())
 
 		By("waiting for the machine to be scheduled once the pool is ready")

--- a/internal/controllers/compute/machine_scheduler_test.go
+++ b/internal/controllers/compute/machine_scheduler_test.go
@@ -21,6 +21,14 @@ import (
 	corev1alpha1 "github.com/ironcore-dev/ironcore/api/core/v1alpha1"
 )
 
+func markMachinePoolReady(machinePool *computev1alpha1.MachinePool) {
+	machinePool.Status.Conditions = computev1alpha1.SetMachinePoolCondition(machinePool.Status.Conditions,
+		computev1alpha1.MachinePoolCondition{
+			Type:   computev1alpha1.MachinePoolReady,
+			Status: corev1.ConditionTrue,
+		})
+}
+
 var _ = Describe("MachineScheduler", func() {
 	ns := SetupNamespace(&k8sClient)
 	machineClass := SetupMachineClass()
@@ -40,6 +48,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating a machine w/ the requested machine class")
@@ -94,6 +103,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("waiting for the machine to be scheduled onto the machine pool")
@@ -118,6 +128,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePoolNoMatchingLabels.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePoolNoMatchingLabels)
 		})).Should(Succeed())
 
 		By("creating a machine pool w/ matching labels")
@@ -137,6 +148,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePoolMatchingLabels.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePoolMatchingLabels)
 		})).Should(Succeed())
 
 		By("creating a machine w/ the requested machine class")
@@ -191,6 +203,7 @@ var _ = Describe("MachineScheduler", func() {
 			taintedMachinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(taintedMachinePool)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -236,6 +249,11 @@ var _ = Describe("MachineScheduler", func() {
 		})
 		Expect(k8sClient.Patch(ctx, machine, client.MergeFrom(machineBase))).To(Succeed(), "failed to patch the machine's spec")
 
+		By("re-asserting the machine pool is ready")
+		Eventually(UpdateStatus(taintedMachinePool, func() {
+			markMachinePoolReady(taintedMachinePool)
+		})).Should(Succeed())
+
 		By("observing the machine is scheduled onto the machine pool")
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: taintedMachinePool.Name})),
@@ -257,6 +275,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -289,6 +308,7 @@ var _ = Describe("MachineScheduler", func() {
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):       resource.MustParse("5"),
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, secondMachineClass.Name): resource.MustParse("100"),
 			}
+			markMachinePoolReady(secondMachinePool)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -326,6 +346,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("50"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -344,6 +365,7 @@ var _ = Describe("MachineScheduler", func() {
 			secondMachinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("50"),
 			}
+			markMachinePoolReady(secondMachinePool)
 		})).Should(Succeed())
 
 		By("creating machines")
@@ -394,6 +416,7 @@ var _ = Describe("MachineScheduler", func() {
 		By("patching the machine pool status to contain a machine class")
 		Eventually(UpdateStatus(machinePool, func() {
 			machinePool.Status.AvailableMachineClasses = []corev1.LocalObjectReference{{Name: machineClass.Name}}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -420,6 +443,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("checking that the machine is scheduled onto the machine pool")
@@ -443,6 +467,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("2"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating the first machine")
@@ -512,6 +537,7 @@ var _ = Describe("MachineScheduler", func() {
 			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("5"),
 			}
+			markMachinePoolReady(machinePool)
 		})).Should(Succeed())
 
 		By("creating a second machine pool")
@@ -545,6 +571,7 @@ var _ = Describe("MachineScheduler", func() {
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name):       resource.MustParse("5"),
 				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, secondMachineClass.Name): resource.MustParse("5"),
 			}
+			markMachinePoolReady(secondMachinePool)
 		})).Should(Succeed())
 
 		By("creating a machine")
@@ -564,6 +591,50 @@ var _ = Describe("MachineScheduler", func() {
 		By("checking that the machine is scheduled onto the machine pool")
 		Eventually(Object(machine)).Should(SatisfyAll(
 			HaveField("Spec.MachinePoolRef.Name", Equal(secondMachinePool.Name)),
+		))
+	})
+
+	It("should not schedule machines onto a machine pool that is not ready", func(ctx SpecContext) {
+		By("creating a machine pool")
+		machinePool := &computev1alpha1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-pool-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, machinePool)).To(Succeed(), "failed to create machine pool")
+
+		By("patching the machine pool status to have capacity but no ready condition")
+		Eventually(UpdateStatus(machinePool, func() {
+			machinePool.Status.AvailableMachineClasses = []corev1.LocalObjectReference{{Name: machineClass.Name}}
+			machinePool.Status.Allocatable = corev1alpha1.ResourceList{
+				corev1alpha1.ClassCountFor(corev1alpha1.ClassTypeMachineClass, machineClass.Name): resource.MustParse("10"),
+			}
+		})).Should(Succeed())
+
+		By("creating a machine w/ the requested machine class")
+		machine := &computev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-machine-",
+			},
+			Spec: computev1alpha1.MachineSpec{
+				MachineClassRef: corev1.LocalObjectReference{Name: machineClass.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed(), "failed to create machine")
+
+		By("observing the machine isn't scheduled onto the not-ready machine pool")
+		Consistently(Object(machine)).Should(HaveField("Spec.MachinePoolRef", BeNil()))
+
+		By("marking the machine pool ready")
+		Eventually(UpdateStatus(machinePool, func() {
+			markMachinePoolReady(machinePool)
+		})).Should(Succeed())
+
+		By("waiting for the machine to be scheduled once the pool is ready")
+		Eventually(Object(machine)).Should(SatisfyAll(
+			HaveField("Spec.MachinePoolRef", Equal(&corev1.LocalObjectReference{Name: machinePool.Name})),
+			HaveField("Status.State", Equal(computev1alpha1.MachineStatePending)),
 		))
 	})
 })


### PR DESCRIPTION
# Proposed Changes

- Enhance machine scheduling to respect `MachinePool` `Ready` condition
  - Skip pools which are not ready of if the condition is missing

Fixes #1531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Machines are now scheduled only to machine pools that report readiness.
  * Unready pools are excluded from scheduling until they become ready, even when capacity is available.
  * Scheduling resumes automatically once a pool reaches the ready state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->