### PR TITLE
Use 'go list' directly to avoid an external 'jq' dependency in codegen script

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -45,7 +45,8 @@ declare -a GOMODS=(
 )
 echo "Setting permissions for files of relevant go modules to 644"
 for MOD in "${GOMODS[@]}"; do
-  find "$(go list -json -m -u "${MOD}" | jq -r '.Dir')" -type f -exec chmod 644 {} +
+  # Use 'go list' directly to avoid an external 'jq' dependency.
+  find "$(go list -m -f '{{.Dir}}' "${MOD}")" -type f -exec chmod 644 {} +
 done
 
 echo "Generating ${blue}openapi${normal}"


### PR DESCRIPTION
# Proposed Changes

- Use 'go list' directly to avoid an external 'jq' dependency in codegen script

Ref to recent to ironcore-net PR: https://github.com/ironcore-dev/ironcore-net/pull/532#discussion_r3733602912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified module permission updates by removing the requirement for the external `jq` utility.
  * Preserved recursive permission updates for configured modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->