### PR TITLE
Use volume provider ID instead of volume name for volume snapshot

### DIFF
--- a/poollet/volumepoollet/controllers/volumesnapshot_controller.go
+++ b/poollet/volumepoollet/controllers/volumesnapshot_controller.go
@@ -276,10 +276,14 @@ func (r *VolumeSnapshotReconciler) prepareIRIVolumeSnapshot(ctx context.Context,
 		return nil, false, fmt.Errorf("error(s) preparing iri volume snapshot metadata: %v", errs)
 	}
 
+	volumeID, err := poolletutils.ParseID(volume.Status.VolumeID)
+	if err != nil {
+		return nil, false, fmt.Errorf("error parsing volume ID: %w", err)
+	}
 	return &iri.VolumeSnapshot{
 		Metadata: metadata,
 		Spec: &iri.VolumeSnapshotSpec{
-			VolumeId: volume.Name,
+			VolumeId: volumeID.ID,
 		},
 	}, true, nil
 }


### PR DESCRIPTION
# Proposed Changes

When creating a VolumeSnapshot, the VolumeSnapshotReconciler uses the
volume name to refer to the volume to snapshot. However, the volume
provider does not know the volume name. Instead, it needs the provider
ID it assigned to the volume.

Fixes #1542


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Volume snapshots now reference the correct underlying volume identifier.
  * Invalid volume identifiers are rejected with a clear error instead of creating an incorrect snapshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->