### PR TITLE
Add `pool-lifecycle-controller` bootstrap identity

### DIFF
--- a/api/compute/v1alpha1/common.go
+++ b/api/compute/v1alpha1/common.go
@@ -23,6 +23,12 @@ const (
 	// MachinePoolUserNamePrefix is the prefix all machine pool users should have.
 	MachinePoolUserNamePrefix = "compute.ironcore.dev:system:machinepool:"
 
+	// PoolLifecycleControllersGroup is the system rbac group the pool-lifecycle-controller is in.
+	PoolLifecycleControllersGroup = "compute.ironcore.dev:system:pool-lifecycle-controllers"
+
+	// PoolLifecycleControllerCommonName is the fixed common name of the pool-lifecycle-controller cert.
+	PoolLifecycleControllerCommonName = "compute.ironcore.dev:system:pool-lifecycle-controller"
+
 	SecretTypeIgnition = corev1.SecretType("compute.ironcore.dev/ignition")
 )
 

--- a/config/apiserver/rbac/kustomization.yaml
+++ b/config/apiserver/rbac/kustomization.yaml
@@ -30,3 +30,9 @@ resources:
 - networkplugin_rolebinding.yaml
 - networkplugin_bootstrapper_role.yaml
 - networkplugin_bootstrapper_rolebinding.yaml
+
+# PoolLifecycle (bootstrapper) roles
+- poollifecycle_bootstrapper_role.yaml
+- poollifecycle_bootstrapper_rolebinding.yaml
+- poollifecycle_role.yaml
+- poollifecycle_rolebinding.yaml

--- a/config/apiserver/rbac/poollifecycle_bootstrapper_role.yaml
+++ b/config/apiserver/rbac/poollifecycle_bootstrapper_role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers-bootstrapper
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/poollifecycleclient
+    verbs:
+      - create

--- a/config/apiserver/rbac/poollifecycle_bootstrapper_rolebinding.yaml
+++ b/config/apiserver/rbac/poollifecycle_bootstrapper_rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers-bootstrapper
+subjects:
+  - kind: Group
+    # Group name has to match bootstrap group pattern \Asystem:bootstrappers:[a-z0-9:-]{0,255}[a-z0-9]\
+    # See https://github.com/kubernetes/kubernetes/blob/e8662a46dd27db774ec953dae15f93ae2d1a68c8/staging/src/k8s.io/cluster-bootstrap/token/api/types.go#L96
+    name: system:bootstrappers:compute-ironcore-dev:poollifecyclecontrollers
+    apiGroup: rbac.authorization.k8s.io

--- a/config/apiserver/rbac/poollifecycle_role.yaml
+++ b/config/apiserver/rbac/poollifecycle_role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers
+rules:
+- apiGroups:
+  - compute.ironcore.dev
+  resources:
+  - machinepools
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - compute.ironcore.dev
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/apiserver/rbac/poollifecycle_rolebinding.yaml
+++ b/config/apiserver/rbac/poollifecycle_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute.ironcore.dev:system:pool-lifecycle-controllers
+subjects:
+  - kind: Group
+    name: compute.ironcore.dev:system:pool-lifecycle-controllers
+    apiGroup: rbac.authorization.k8s.io

--- a/internal/apis/compute/common.go
+++ b/internal/apis/compute/common.go
@@ -17,6 +17,12 @@ const (
 
 	// MachinePoolUserNamePrefix is the prefix all machine pool users should have.
 	MachinePoolUserNamePrefix = "compute.ironcore.dev:system:machinepool:"
+
+	// PoolLifecycleControllersGroup is the system rbac group the pool-lifecycle-controller is in.
+	PoolLifecycleControllersGroup = "compute.ironcore.dev:system:pool-lifecycle-controllers"
+
+	// PoolLifecycleControllerCommonName is the fixed common name of the pool-lifecycle-controller cert.
+	PoolLifecycleControllerCommonName = "compute.ironcore.dev:system:pool-lifecycle-controller"
 )
 
 // MachinePoolCommonName constructs the common name for a certificate of a machine pool user.

--- a/internal/controllers/core/certificate/compute/poollifecycle.go
+++ b/internal/controllers/core/certificate/compute/poollifecycle.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package compute
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	computev1alpha1 "github.com/ironcore-dev/ironcore/api/compute/v1alpha1"
+	"github.com/ironcore-dev/ironcore/internal/controllers/core/certificate/generic"
+	"golang.org/x/exp/slices"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var PoolLifecycleControllerRequiredUsages = sets.New[certificatesv1.KeyUsage](
+	certificatesv1.UsageDigitalSignature,
+	certificatesv1.UsageKeyEncipherment,
+	certificatesv1.UsageClientAuth,
+)
+
+func IsPoolLifecycleControllerClientCert(csr *certificatesv1.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if csr.Spec.SignerName != certificatesv1.KubeAPIServerClientSignerName {
+		return false
+	}
+
+	return ValidatePoolLifecycleControllerClientCSR(x509cr, sets.New(csr.Spec.Usages...)) == nil
+}
+
+func ValidatePoolLifecycleControllerClientCSR(req *x509.CertificateRequest, usages sets.Set[certificatesv1.KeyUsage]) error {
+	if !slices.Equal([]string{computev1alpha1.PoolLifecycleControllersGroup}, req.Subject.Organization) {
+		return fmt.Errorf("organization is not %s", computev1alpha1.PoolLifecycleControllersGroup)
+	}
+
+	if len(req.DNSNames) > 0 {
+		return fmt.Errorf("dns subject alternative names are not allowed")
+	}
+	if len(req.EmailAddresses) > 0 {
+		return fmt.Errorf("email subject alternative names are not allowed")
+	}
+	if len(req.IPAddresses) > 0 {
+		return fmt.Errorf("ip subject alternative names are not allowed")
+	}
+	if len(req.URIs) > 0 {
+		return fmt.Errorf("uri subject alternative names are not allowed")
+	}
+
+	if req.Subject.CommonName != computev1alpha1.PoolLifecycleControllerCommonName {
+		return fmt.Errorf("subject common name is not %s", computev1alpha1.PoolLifecycleControllerCommonName)
+	}
+
+	if !PoolLifecycleControllerRequiredUsages.Equal(usages) {
+		return fmt.Errorf("usages did not match %v", sets.List(PoolLifecycleControllerRequiredUsages))
+	}
+
+	return nil
+}
+
+var (
+	PoolLifecycleControllerRecognizer = generic.NewCertificateSigningRequestRecognizer(
+		IsPoolLifecycleControllerClientCert,
+		authorizationv1.ResourceAttributes{
+			Group:       certificatesv1.GroupName,
+			Resource:    "certificatesigningrequests",
+			Verb:        "create",
+			Subresource: "poollifecycleclient",
+		},
+		"Auto approving pool-lifecycle-controller client certificate after SubjectAccessReview.",
+	)
+)
+
+func init() {
+	Recognizers = append(Recognizers, PoolLifecycleControllerRecognizer)
+}


### PR DESCRIPTION
# Proposed Changes
- Auto-approve the `pool-lifecycle-controller` CSR via a new recognizer 
- Add bootstrapper + runtime RBAC
- Add `PoolLifecycleControllersGroup` / `PoolLifecycleControllerCommonName` constants

Fixes https://github.com/ironcore-dev/pool-lifecycle-controller/issues/5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RBAC permissions for pool-lifecycle controllers and their bootstrap process.
  - Enabled controllers to manage machine pools and read machine resources.
  - Added certificate-based authentication and validation for pool-lifecycle controller clients.
  - Registered the pool-lifecycle controller certificate recognizer with the API server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->