### PR TITLE
Fix inverted CSR recognizer check in certificate approval controller

### DIFF
--- a/internal/controllers/core/certificateapproval_controller.go
+++ b/internal/controllers/core/certificateapproval_controller.go
@@ -50,7 +50,7 @@ func (r *CertificateApprovalReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	var tried []string
 	for _, recognizer := range r.Recognizers {
-		if recognizer.Recognize(csr, x509CR) {
+		if !recognizer.Recognize(csr, x509CR) {
 			continue
 		}
 

--- a/internal/controllers/core/certificateapproval_test.go
+++ b/internal/controllers/core/certificateapproval_test.go
@@ -32,7 +32,13 @@ var _ = Describe("CertificateApprovalController", func() {
 						Organization: []string{organization},
 					},
 				},
-				utilcertificate.DefaultKubeAPIServerClientGetUsages,
+				func(_ any) []certificatesv1.KeyUsage {
+					return []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageClientAuth,
+					}
+				},
 				nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -60,6 +66,41 @@ var _ = Describe("CertificateApprovalController", func() {
 		Entry("network plugin",
 			networkingv1alpha1.NetworkPluginCommonName("my-plugin"),
 			networkingv1alpha1.NetworkPluginsGroup,
+		),
+	)
+
+	DescribeTable("certificate denial",
+		func(ctx SpecContext, commonName, organization string) {
+			By("creating a non-conformant certificate signing request")
+			csr, _, _, err := utilcertificate.GenerateAndCreateCertificateSigningRequest(
+				ctx,
+				k8sClient,
+				certificatesv1.KubeAPIServerClientSignerName,
+				&x509.CertificateRequest{
+					Subject: pkix.Name{
+						CommonName:   commonName,
+						Organization: []string{organization},
+					},
+				},
+				utilcertificate.DefaultKubeAPIServerClientGetUsages,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring the csr is never approved")
+			Consistently(ctx, Object(csr)).Should(
+				HaveField("Status.Conditions", Not(ContainElement(
+					HaveField("Type", certificatesv1.CertificateApproved),
+				))),
+			)
+		},
+		Entry("non-conformant certificate",
+			"pwn",
+			"unknown-org",
+		),
+		Entry("elevated organization",
+			"kubernetes-admin",
+			"kubeadm:cluster-admins",
 		),
 	)
 })

--- a/internal/controllers/core/core_suite_test.go
+++ b/internal/controllers/core/core_suite_test.go
@@ -147,6 +147,8 @@ var _ = BeforeSuite(func() {
 		err = k8sManager.Start(mgrCtx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
+
+	Expect(k8sManager.GetCache().WaitForCacheSync(mgrCtx)).To(BeTrue())
 })
 
 func SetupTest(ctx context.Context) *corev1.Namespace {


### PR DESCRIPTION
This PR addresses security advisory GHSA-rwxr-qr3p-5xq2.

The CSR recognizer loop condition was inverted, causing the controller to approve CSRs that did not match any recognizer instead of those that did. Anyone with bootstrapping credentials could submit forged CSR and they got auto approved

**Changes**

 - certificateapproval_controller.go: fix inverted condition  if !recognizer.Recognize(...)
  - certificateapproval_test.go: added expected key usages (encipherment) and added negative test cases verifying that non-conformant CSRs and privilege-escalating CSRs are never approved.
  - core_suite_test.go: added wait for manager cache sync before tests run to prevent a race condition where CSRs created before the informer cache is ready would never be reconciled.