### PR TITLE
Add mutating admission policy RBAC to apiserver role

### DIFF
--- a/config/apiserver/rbac/apiserver_role.yaml
+++ b/config/apiserver/rbac/apiserver_role.yaml
@@ -31,6 +31,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
+      - mutatingadmissionpolicies
+      - mutatingadmissionpolicybindings
       - validatingadmissionpolicies
       - validatingadmissionpolicybindings
     verbs:


### PR DESCRIPTION
# Proposed Changes

  - Add `mutatingadmissionpolicies` and `mutatingadmissionpolicybindings` (get/list/watch) to the `apiserver-role` ClusterRole.
  - As of Kubernetes 1.36, `MutatingAdmissionPolicy`/`MutatingAdmissionPolicyBinding` are served as GA (`admissionregistration.k8s.io/v1`). The aggregated apiserver's admission
  informers now watch them; without the RBAC grant the informers hit `forbidden` errors and never sync, so the `informer-sync` readyz check fails and the apiserver pod never becomes
  Ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission policy management by enabling the system to read and monitor mutating admission policies and their bindings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->