### PR TITLE
Set Dependabot's cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       go-dependencies:
         patterns:
@@ -16,6 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       gh-actions-dependencies:
         patterns:
@@ -24,6 +28,8 @@ updates:
     directory: "/docs"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       pip-dependencies:
         patterns:
@@ -34,6 +40,8 @@ updates:
       - "/docs"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       docker-dependencies:
         patterns:


### PR DESCRIPTION
Dependabot won't bump packages to versions that are less than 7 days old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates are now held for seven days before being proposed, allowing additional time for update monitoring and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->